### PR TITLE
perf: add optimized Clang builds and vector fast paths

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -97,8 +97,8 @@ default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-nonportable-include-path -
 default-CXXFLAGS := $(default-CFLAGS) -std=c++2a
 
 mcppbs-CPPFLAGS := @CPPFLAGS@
-mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@
-mcppbs-CXXFLAGS := $(default-CXXFLAGS) @CXXFLAGS@
+mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@ @SPIKE_OPT_CFLAGS@
+mcppbs-CXXFLAGS := $(default-CXXFLAGS) @CXXFLAGS@ @SPIKE_OPT_CFLAGS@
 
 CC            := @CC@
 CXX           := @CXX@
@@ -118,7 +118,7 @@ COMPILE_C     := $(CC) -MMD -MP $(all-c-flags) $(sprojs_include)
 #  - LDFLAGS : Flags for the linker (eg. -L)
 #  - LIBS    : Library flags (eg. -l)
 
-mcppbs-LDFLAGS := @LDFLAGS@ @BOOST_LDFLAGS@
+mcppbs-LDFLAGS := @SPIKE_OPT_LDFLAGS@ @LDFLAGS@ @BOOST_LDFLAGS@
 all-link-flags := $(mcppbs-LDFLAGS) $(LDFLAGS)
 
 comma := ,

--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ install path.
 If your system uses the `yum` package manager, you can substitute
 `yum install dtc` for the first step.
 
+Optimized Clang Build
+---------------------
+
+By default, `configure` uses Clang 21 with `-O3`, host-native code generation,
+and ThinLTO when the matching LLVM tools are available.  Otherwise it warns
+and falls back to the normal compiler search, which selects GCC on typical
+Linux systems.  Explicit `CC`, `CXX`, `AR`, and `RANLIB` settings take
+precedence over automatic selection.
+
+    $ mkdir build-clang-lto
+    $ cd build-clang-lto
+    $ ../configure --prefix=$RISCV
+    $ make
+
+Use `--enable-clang-lto=VERSION` to select another versioned LLVM toolchain,
+or `--disable-clang-lto` to force the normal compiler search.
+
+Because this mode uses `-march=native`, its binaries are not necessarily
+portable to other host CPUs.
+
 Build Steps on OpenBSD
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ install path.
 If your system uses the `yum` package manager, you can substitute
 `yum install dtc` for the first step.
 
+Optimized Clang Build
+---------------------
+
+By default, `configure` uses Clang 21 with `-O3`, host-native code generation,
+ThinLTO, and the matching LLVM linker when that toolchain can build and link a
+C++ program.  Otherwise it warns and falls back to the normal compiler search,
+which selects GCC on typical Linux systems.  Explicit `CC`, `CXX`, `AR`, and
+`RANLIB` settings take precedence over automatic selection.
+
+If Clang's default GCC runtime is incomplete, `configure` also tries the
+runtime used by the system `g++` before falling back.
+
+    $ mkdir build-clang-lto
+    $ cd build-clang-lto
+    $ ../configure --prefix=$RISCV
+    $ make
+
+Use `--enable-clang-lto=VERSION` to select another versioned LLVM toolchain,
+or `--disable-clang-lto` to force the normal compiler search.  An explicitly
+requested toolchain causes a configuration error instead of falling back when
+it is incomplete or unusable.
+
+Because this mode uses `-march=native`, its binaries are not necessarily
+portable to other host CPUs.
+
 Build Steps on OpenBSD
 ----------------------
 

--- a/configure
+++ b/configure
@@ -658,6 +658,8 @@ INSTALL_PROGRAM
 STOW_PREFIX
 STOW_ROOT
 enable_stow
+SPIKE_OPT_LDFLAGS
+SPIKE_OPT_CFLAGS
 DTC
 RANLIB
 AR
@@ -721,6 +723,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_clang_lto
 enable_stow
 enable_optional_subprojects
 with_boost
@@ -1365,6 +1368,10 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-clang-lto[=VERSION]
+                          prefer an optimized host-native Clang ThinLTO build;
+                          VERSION selects LLVM tools (default: auto-detect
+                          version 21)
   --enable-stow           Enable stow-based install
   --enable-optional-subprojects
                           Enable all optional subprojects
@@ -3220,6 +3227,113 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
+
+#-------------------------------------------------------------------------
+# Build profiles
+#-------------------------------------------------------------------------
+
+# Check whether --enable-clang-lto was given.
+if test ${enable_clang_lto+y}
+then :
+  enableval=$enable_clang_lto; enable_clang_lto=$enableval
+else case e in #(
+  e) enable_clang_lto=auto ;;
+esac
+fi
+
+
+case "$enable_clang_lto" in
+  auto|yes)
+    spike_llvm_suffix=-21
+    ;;
+  no)
+    ;;
+  *[!0-9]*|'')
+    as_fn_error $? "--enable-clang-lto accepts only a numeric LLVM version" "$LINENO" 5
+    ;;
+  *)
+    spike_llvm_suffix="-$enable_clang_lto"
+    ;;
+esac
+
+spike_use_clang_lto=no
+
+if test "x$enable_clang_lto" != xno
+then :
+
+  spike_clang_cc=clang$spike_llvm_suffix
+  spike_clang_cxx=clang++$spike_llvm_suffix
+  spike_clang_ar=llvm-ar$spike_llvm_suffix
+  spike_clang_ranlib=llvm-ranlib$spike_llvm_suffix
+
+  if test "x$enable_clang_lto" = xauto && test "x$build" != "x$host"
+then :
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: cross-compiling; skipping automatic Clang ThinLTO selection" >&5
+printf "%s\n" "$as_me: cross-compiling; skipping automatic Clang ThinLTO selection" >&6;}
+
+else case e in #(
+  e)
+    if test "x$enable_clang_lto" = xauto &&
+           { test -n "${CC-}" || test -n "${CXX-}" ||
+             test -n "${AR-}" || test -n "${RANLIB-}"; }
+then :
+
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: compiler tools were supplied; skipping automatic Clang ThinLTO selection" >&5
+printf "%s\n" "$as_me: compiler tools were supplied; skipping automatic Clang ThinLTO selection" >&6;}
+
+else case e in #(
+  e)
+      if test -n "${CC-}" || test -n "${CXX-}" ||
+             test -n "${AR-}" || test -n "${RANLIB-}"
+then :
+
+        CC=${CC:-$spike_clang_cc}
+        CXX=${CXX:-$spike_clang_cxx}
+        AR=${AR:-$spike_clang_ar}
+        RANLIB=${RANLIB:-$spike_clang_ranlib}
+        spike_use_clang_lto=yes
+
+else case e in #(
+  e)
+        spike_missing_llvm_tools=
+        for spike_llvm_tool in "$spike_clang_cc" "$spike_clang_cxx" \
+                               "$spike_clang_ar" "$spike_clang_ranlib"; do
+          if command -v "$spike_llvm_tool" >/dev/null 2>&1 &&
+             "$spike_llvm_tool" --version >/dev/null 2>&1; then
+            :
+          else
+            spike_missing_llvm_tools="$spike_missing_llvm_tools $spike_llvm_tool"
+          fi
+        done
+
+        if test -z "$spike_missing_llvm_tools"
+then :
+
+          CC=$spike_clang_cc
+          CXX=$spike_clang_cxx
+          AR=$spike_clang_ar
+          RANLIB=$spike_clang_ranlib
+          spike_use_clang_lto=yes
+
+else case e in #(
+  e)
+          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Clang ThinLTO tools unavailable:$spike_missing_llvm_tools; falling back to the default toolchain" >&5
+printf "%s\n" "$as_me: WARNING: Clang ThinLTO tools unavailable:$spike_missing_llvm_tools; falling back to the default toolchain" >&2;}
+         ;;
+esac
+fi
+       ;;
+esac
+fi
+     ;;
+esac
+fi
+   ;;
+esac
+fi
+
+fi
 
 #-------------------------------------------------------------------------
 # Checks for programs
@@ -5170,6 +5284,461 @@ printf "%s\n" "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
      as_fn_error $? "unknown endianness
  presetting ac_cv_c_bigendian=no (or yes) will help" "$LINENO" 5 ;;
  esac
+
+
+SPIKE_OPT_CFLAGS=
+SPIKE_OPT_LDFLAGS=
+
+
+if test "x$spike_use_clang_lto" = xyes
+then :
+
+  spike_cc_is_clang=no
+  spike_cxx_is_clang=no
+
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC is Clang" >&5
+printf %s "checking whether $CC is Clang... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#ifndef __clang__
+# error This compiler is not Clang
+#endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }; spike_cc_is_clang=yes
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; } ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CXX is Clang" >&5
+printf %s "checking whether $CXX is Clang... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#ifndef __clang__
+# error This compiler is not Clang
+#endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }; spike_cxx_is_clang=yes
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; } ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+  if test "x$spike_cc_is_clang" = xyes &&
+         test "x$spike_cxx_is_clang" = xyes
+then :
+
+    spike_clang_lto_flags_ok=yes
+
+    ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -O3" >&5
+printf %s "checking whether the C compiler accepts -O3... " >&6; }
+if test ${ax_cv_check_cflags___O3+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  if test x"$GCC" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  CFLAGS="$CFLAGS  -O3 $add_gnu_werror"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___O3=yes
+else case e in #(
+  e) ax_cv_check_cflags___O3=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___O3" >&5
+printf "%s\n" "$ax_cv_check_cflags___O3" >&6; }
+if test "x$ax_cv_check_cflags___O3" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -march=native" >&5
+printf %s "checking whether the C compiler accepts -march=native... " >&6; }
+if test ${ax_cv_check_cflags___march_native+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  if test x"$GCC" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  CFLAGS="$CFLAGS  -march=native $add_gnu_werror"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___march_native=yes
+else case e in #(
+  e) ax_cv_check_cflags___march_native=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___march_native" >&5
+printf "%s\n" "$ax_cv_check_cflags___march_native" >&6; }
+if test "x$ax_cv_check_cflags___march_native" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -flto=thin" >&5
+printf %s "checking whether the C compiler accepts -flto=thin... " >&6; }
+if test ${ax_cv_check_cflags___flto_thin+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  if test x"$GCC" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  CFLAGS="$CFLAGS  -flto=thin $add_gnu_werror"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___flto_thin=yes
+else case e in #(
+  e) ax_cv_check_cflags___flto_thin=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___flto_thin" >&5
+printf "%s\n" "$ax_cv_check_cflags___flto_thin" >&6; }
+if test "x$ax_cv_check_cflags___flto_thin" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C++ compiler accepts -O3" >&5
+printf %s "checking whether the C++ compiler accepts -O3... " >&6; }
+if test ${ax_cv_check_cxxflags___O3+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CXXFLAGS
+  if test x"$GXX" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  CXXFLAGS="$CXXFLAGS  -O3 $add_gnu_werror"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"
+then :
+  ax_cv_check_cxxflags___O3=yes
+else case e in #(
+  e) ax_cv_check_cxxflags___O3=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___O3" >&5
+printf "%s\n" "$ax_cv_check_cxxflags___O3" >&6; }
+if test "x$ax_cv_check_cxxflags___O3" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C++ compiler accepts -march=native" >&5
+printf %s "checking whether the C++ compiler accepts -march=native... " >&6; }
+if test ${ax_cv_check_cxxflags___march_native+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CXXFLAGS
+  if test x"$GXX" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  CXXFLAGS="$CXXFLAGS  -march=native $add_gnu_werror"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"
+then :
+  ax_cv_check_cxxflags___march_native=yes
+else case e in #(
+  e) ax_cv_check_cxxflags___march_native=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___march_native" >&5
+printf "%s\n" "$ax_cv_check_cxxflags___march_native" >&6; }
+if test "x$ax_cv_check_cxxflags___march_native" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C++ compiler accepts -flto=thin" >&5
+printf %s "checking whether the C++ compiler accepts -flto=thin... " >&6; }
+if test ${ax_cv_check_cxxflags___flto_thin+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CXXFLAGS
+  if test x"$GXX" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  CXXFLAGS="$CXXFLAGS  -flto=thin $add_gnu_werror"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"
+then :
+  ax_cv_check_cxxflags___flto_thin=yes
+else case e in #(
+  e) ax_cv_check_cxxflags___flto_thin=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___flto_thin" >&5
+printf "%s\n" "$ax_cv_check_cxxflags___flto_thin" >&6; }
+if test "x$ax_cv_check_cxxflags___flto_thin" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the linker accepts -flto=thin" >&5
+printf %s "checking whether the linker accepts -flto=thin... " >&6; }
+if test ${ax_cv_check_ldflags___flto_thin+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS  -flto=thin"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  ax_cv_check_ldflags___flto_thin=yes
+else case e in #(
+  e) ax_cv_check_ldflags___flto_thin=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LDFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_ldflags___flto_thin" >&5
+printf "%s\n" "$ax_cv_check_ldflags___flto_thin" >&6; }
+if test "x$ax_cv_check_ldflags___flto_thin" = xyes
+then :
+  :
+else case e in #(
+  e) spike_clang_lto_flags_ok=no ;;
+esac
+fi
+
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    if test "x$spike_clang_lto_flags_ok" = xyes
+then :
+
+      SPIKE_OPT_CFLAGS="-O3 -march=native -flto=thin"
+      SPIKE_OPT_LDFLAGS="-flto=thin"
+
+else case e in #(
+  e)
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Clang ThinLTO flags are unsupported; continuing without the optimized build profile" >&5
+printf "%s\n" "$as_me: WARNING: Clang ThinLTO flags are unsupported; continuing without the optimized build profile" >&2;}
+     ;;
+esac
+fi
+
+else case e in #(
+  e)
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: the selected compilers are not Clang; continuing without the optimized build profile" >&5
+printf "%s\n" "$as_me: WARNING: the selected compilers are not Clang; continuing without the optimized build profile" >&2;}
+   ;;
+esac
+fi
+
+fi
+
+
 
 
 #-------------------------------------------------------------------------

--- a/configure
+++ b/configure
@@ -658,6 +658,8 @@ INSTALL_PROGRAM
 STOW_PREFIX
 STOW_ROOT
 enable_stow
+SPIKE_OPT_LDFLAGS
+SPIKE_OPT_CFLAGS
 DTC
 RANLIB
 AR
@@ -721,6 +723,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_clang_lto
 enable_stow
 with_boost
 with_boost_libdir
@@ -1365,6 +1368,10 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-clang-lto[=VERSION]
+                          prefer an optimized host-native Clang ThinLTO build;
+                          VERSION selects LLVM tools (default: auto-detect
+                          version 21)
   --enable-stow           Enable stow-based install
   --enable-optional-subprojects
                           Enable all optional subprojects
@@ -3220,6 +3227,218 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
+
+#-------------------------------------------------------------------------
+# Build profiles
+#-------------------------------------------------------------------------
+
+# Check whether --enable-clang-lto was given.
+if test ${enable_clang_lto+y}
+then :
+  enableval=$enable_clang_lto; enable_clang_lto=$enableval
+else case e in #(
+  e) enable_clang_lto=auto ;;
+esac
+fi
+
+
+case "$enable_clang_lto" in
+  auto)
+    spike_llvm_suffix=-21
+    spike_clang_lto_required=no
+    ;;
+  yes)
+    spike_llvm_suffix=-21
+    spike_clang_lto_required=yes
+    ;;
+  no)
+    spike_clang_lto_required=no
+    ;;
+  *[!0-9]*|'')
+    as_fn_error $? "--enable-clang-lto accepts only a numeric LLVM version" "$LINENO" 5
+    ;;
+  *)
+    spike_llvm_suffix="-$enable_clang_lto"
+    spike_clang_lto_required=yes
+    ;;
+esac
+
+spike_use_clang_lto=no
+
+if test "x$enable_clang_lto" != xno
+then :
+
+  spike_clang_cc=clang$spike_llvm_suffix
+  spike_clang_cxx=clang++$spike_llvm_suffix
+  spike_clang_ar=llvm-ar$spike_llvm_suffix
+  spike_clang_ranlib=llvm-ranlib$spike_llvm_suffix
+  spike_clang_ld=ld.lld$spike_llvm_suffix
+
+  if test "x$enable_clang_lto" = xauto && test "x$build" != "x$host"
+then :
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: cross-compiling; skipping automatic Clang ThinLTO selection" >&5
+printf "%s\n" "$as_me: cross-compiling; skipping automatic Clang ThinLTO selection" >&6;}
+
+else case e in #(
+  e)
+    if test "x$enable_clang_lto" = xauto &&
+           { test -n "${CC-}" || test -n "${CXX-}" ||
+             test -n "${AR-}" || test -n "${RANLIB-}"; }
+then :
+
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: compiler tools were supplied; skipping automatic Clang ThinLTO selection" >&5
+printf "%s\n" "$as_me: compiler tools were supplied; skipping automatic Clang ThinLTO selection" >&6;}
+
+else case e in #(
+  e)
+      CC=${CC:-$spike_clang_cc}
+      CXX=${CXX:-$spike_clang_cxx}
+      AR=${AR:-$spike_clang_ar}
+      RANLIB=${RANLIB:-$spike_clang_ranlib}
+
+      spike_missing_llvm_tools=
+      for spike_llvm_tool in "$CC" "$CXX" "$AR" "$RANLIB" \
+                             "$spike_clang_ld"; do
+        if command -v "$spike_llvm_tool" >/dev/null 2>&1 &&
+           "$spike_llvm_tool" --version >/dev/null 2>&1; then
+          :
+        else
+          spike_missing_llvm_tools="$spike_missing_llvm_tools $spike_llvm_tool"
+        fi
+      done
+
+      if test -z "$spike_missing_llvm_tools"
+then :
+
+        spike_clang_ld_path=`command -v "$spike_clang_ld"`
+        spike_clang_ld_flag="--ld-path=$spike_clang_ld_path"
+
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the Clang ThinLTO toolchain can build a C++ program" >&5
+printf %s "checking whether the Clang ThinLTO toolchain can build a C++ program... " >&6; }
+        cat > conftest.c <<'_ACEOF'
+int spike_lto_probe(void) { return 0; }
+_ACEOF
+        cat > conftest.cpp <<'_ACEOF'
+#include <thread>
+extern "C" int spike_lto_probe(void);
+static void spike_thread_probe(void) {}
+int main(void) {
+  std::thread thread(spike_thread_probe);
+  thread.join();
+  return spike_lto_probe();
+}
+_ACEOF
+        spike_try_clang_lto ()
+        {
+          rm -f conftest conftest.o conftest.a
+          if test -n "$spike_clang_gcc_flag"; then
+            "$CC" "$spike_clang_gcc_flag" -O3 -march=native -flto=thin \
+              -c conftest.c -o conftest.o >/dev/null 2>&1 &&
+            "$AR" cr conftest.a conftest.o >/dev/null 2>&1 &&
+            "$RANLIB" conftest.a >/dev/null 2>&1 &&
+            "$CXX" "$spike_clang_gcc_flag" -O3 -march=native -flto=thin \
+              "$spike_clang_ld_flag" -pthread conftest.cpp conftest.a \
+              -o conftest >/dev/null 2>&1
+          else
+            "$CC" -O3 -march=native -flto=thin \
+              -c conftest.c -o conftest.o >/dev/null 2>&1 &&
+            "$AR" cr conftest.a conftest.o >/dev/null 2>&1 &&
+            "$RANLIB" conftest.a >/dev/null 2>&1 &&
+            "$CXX" -O3 -march=native -flto=thin "$spike_clang_ld_flag" \
+              -pthread conftest.cpp conftest.a -o conftest >/dev/null 2>&1
+          fi
+        }
+
+        spike_clang_gcc_flag=
+        spike_clang_probe_ok=no
+        if spike_try_clang_lto
+then :
+
+          spike_clang_probe_ok=yes
+
+fi
+
+        if test "x$spike_clang_probe_ok" = xno && command -v g++ >/dev/null 2>&1
+then :
+
+          spike_system_libstdcxx=`g++ -print-file-name=libstdc++.so 2>/dev/null`
+          if test -f "$spike_system_libstdcxx"
+then :
+
+            spike_system_gcc_dir=${spike_system_libstdcxx%/*}
+            spike_clang_gcc_flag="--gcc-install-dir=$spike_system_gcc_dir"
+            if spike_try_clang_lto
+then :
+
+              spike_clang_probe_ok="yes, using $spike_system_gcc_dir"
+
+fi
+
+fi
+
+fi
+        rm -f conftest conftest.c conftest.cpp conftest.o conftest.a
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $spike_clang_probe_ok" >&5
+printf "%s\n" "$spike_clang_probe_ok" >&6; }
+
+        if test "x$spike_clang_probe_ok" != xno
+then :
+
+          if test -n "$spike_clang_gcc_flag"
+then :
+
+            CC="$CC $spike_clang_gcc_flag"
+            CXX="$CXX $spike_clang_gcc_flag"
+
+fi
+          spike_use_clang_lto=yes
+
+else case e in #(
+  e)
+          if test "x$spike_clang_lto_required" = xyes
+then :
+
+            as_fn_error $? "the requested Clang ThinLTO toolchain cannot build and link a C++ program" "$LINENO" 5
+
+else case e in #(
+  e)
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Clang ThinLTO toolchain is unusable; falling back to the default toolchain" >&5
+printf "%s\n" "$as_me: WARNING: Clang ThinLTO toolchain is unusable; falling back to the default toolchain" >&2;}
+            unset CC CXX AR RANLIB
+           ;;
+esac
+fi
+         ;;
+esac
+fi
+
+else case e in #(
+  e)
+        if test "x$spike_clang_lto_required" = xyes
+then :
+
+          as_fn_error $? "required Clang ThinLTO tools unavailable:$spike_missing_llvm_tools" "$LINENO" 5
+
+else case e in #(
+  e)
+          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Clang ThinLTO tools unavailable:$spike_missing_llvm_tools; falling back to the default toolchain" >&5
+printf "%s\n" "$as_me: WARNING: Clang ThinLTO tools unavailable:$spike_missing_llvm_tools; falling back to the default toolchain" >&2;}
+          unset CC CXX AR RANLIB
+         ;;
+esac
+fi
+       ;;
+esac
+fi
+     ;;
+esac
+fi
+   ;;
+esac
+fi
+
+fi
 
 #-------------------------------------------------------------------------
 # Checks for programs
@@ -5170,6 +5389,20 @@ printf "%s\n" "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
      as_fn_error $? "unknown endianness
  presetting ac_cv_c_bigendian=no (or yes) will help" "$LINENO" 5 ;;
  esac
+
+
+SPIKE_OPT_CFLAGS=
+SPIKE_OPT_LDFLAGS=
+
+if test "x$spike_use_clang_lto" = xyes
+then :
+
+  SPIKE_OPT_CFLAGS="-O3 -march=native -flto=thin"
+  SPIKE_OPT_LDFLAGS="-flto=thin $spike_clang_ld_flag"
+
+fi
+
+
 
 
 #-------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,79 @@ m4_include(m4/ax_boost_asio.m4)
 m4_include(m4/ax_boost_regex.m4)
 
 #-------------------------------------------------------------------------
+# Build profiles
+#-------------------------------------------------------------------------
+
+AC_ARG_ENABLE([clang-lto],
+  [AS_HELP_STRING([--enable-clang-lto@<:@=VERSION@:>@],
+    [prefer an optimized host-native Clang ThinLTO build; VERSION selects LLVM tools (default: auto-detect version 21)])],
+  [enable_clang_lto=$enableval],
+  [enable_clang_lto=auto])
+
+case "$enable_clang_lto" in
+  auto|yes)
+    spike_llvm_suffix=-21
+    ;;
+  no)
+    ;;
+  *[[!0-9]]*|'')
+    AC_MSG_ERROR([--enable-clang-lto accepts only a numeric LLVM version])
+    ;;
+  *)
+    spike_llvm_suffix="-$enable_clang_lto"
+    ;;
+esac
+
+spike_use_clang_lto=no
+
+AS_IF([test "x$enable_clang_lto" != xno], [
+  spike_clang_cc=clang$spike_llvm_suffix
+  spike_clang_cxx=clang++$spike_llvm_suffix
+  spike_clang_ar=llvm-ar$spike_llvm_suffix
+  spike_clang_ranlib=llvm-ranlib$spike_llvm_suffix
+
+  AS_IF([test "x$enable_clang_lto" = xauto && test "x$build" != "x$host"], [
+    AC_MSG_NOTICE([cross-compiling; skipping automatic Clang ThinLTO selection])
+  ], [
+    AS_IF([test "x$enable_clang_lto" = xauto &&
+           { test -n "${CC-}" || test -n "${CXX-}" ||
+             test -n "${AR-}" || test -n "${RANLIB-}"; }], [
+      AC_MSG_NOTICE([compiler tools were supplied; skipping automatic Clang ThinLTO selection])
+    ], [
+      AS_IF([test -n "${CC-}" || test -n "${CXX-}" ||
+             test -n "${AR-}" || test -n "${RANLIB-}"], [
+        CC=${CC:-$spike_clang_cc}
+        CXX=${CXX:-$spike_clang_cxx}
+        AR=${AR:-$spike_clang_ar}
+        RANLIB=${RANLIB:-$spike_clang_ranlib}
+        spike_use_clang_lto=yes
+      ], [
+        spike_missing_llvm_tools=
+        for spike_llvm_tool in "$spike_clang_cc" "$spike_clang_cxx" \
+                               "$spike_clang_ar" "$spike_clang_ranlib"; do
+          if command -v "$spike_llvm_tool" >/dev/null 2>&1 &&
+             "$spike_llvm_tool" --version >/dev/null 2>&1; then
+            :
+          else
+            spike_missing_llvm_tools="$spike_missing_llvm_tools $spike_llvm_tool"
+          fi
+        done
+
+        AS_IF([test -z "$spike_missing_llvm_tools"], [
+          CC=$spike_clang_cc
+          CXX=$spike_clang_cxx
+          AR=$spike_clang_ar
+          RANLIB=$spike_clang_ranlib
+          spike_use_clang_lto=yes
+        ], [
+          AC_MSG_WARN([Clang ThinLTO tools unavailable:$spike_missing_llvm_tools; falling back to the default toolchain])
+        ])
+      ])
+    ])
+  ])
+])
+
+#-------------------------------------------------------------------------
 # Checks for programs
 #-------------------------------------------------------------------------
 
@@ -65,6 +138,68 @@ AS_IF([test x"$DTC" == xno],AC_MSG_ERROR([device-tree-compiler not found]))
 AC_DEFINE_UNQUOTED(DTC, ["dtc"], [Executable name of device-tree-compiler])
 
 AC_C_BIGENDIAN
+
+SPIKE_OPT_CFLAGS=
+SPIKE_OPT_LDFLAGS=
+
+AS_IF([test "x$spike_use_clang_lto" = xyes], [
+  spike_cc_is_clang=no
+  spike_cxx_is_clang=no
+
+  AC_LANG_PUSH([C])
+  AC_MSG_CHECKING([whether $CC is Clang])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[
+#ifndef __clang__
+# error This compiler is not Clang
+#endif
+    ]])],
+    [AC_MSG_RESULT([yes]); spike_cc_is_clang=yes],
+    [AC_MSG_RESULT([no])])
+  AC_LANG_POP([C])
+
+  AC_LANG_PUSH([C++])
+  AC_MSG_CHECKING([whether $CXX is Clang])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[
+#ifndef __clang__
+# error This compiler is not Clang
+#endif
+    ]])],
+    [AC_MSG_RESULT([yes]); spike_cxx_is_clang=yes],
+    [AC_MSG_RESULT([no])])
+  AC_LANG_POP([C++])
+
+  AS_IF([test "x$spike_cc_is_clang" = xyes &&
+         test "x$spike_cxx_is_clang" = xyes], [
+    spike_clang_lto_flags_ok=yes
+
+    AC_LANG_PUSH([C])
+    AX_CHECK_COMPILE_FLAG([-O3], [], [spike_clang_lto_flags_ok=no])
+    AX_CHECK_COMPILE_FLAG([-march=native], [], [spike_clang_lto_flags_ok=no])
+    AX_CHECK_COMPILE_FLAG([-flto=thin], [], [spike_clang_lto_flags_ok=no])
+    AC_LANG_POP([C])
+
+    AC_LANG_PUSH([C++])
+    AX_CHECK_COMPILE_FLAG([-O3], [], [spike_clang_lto_flags_ok=no])
+    AX_CHECK_COMPILE_FLAG([-march=native], [], [spike_clang_lto_flags_ok=no])
+    AX_CHECK_COMPILE_FLAG([-flto=thin], [], [spike_clang_lto_flags_ok=no])
+    AX_CHECK_LINK_FLAG([-flto=thin], [], [spike_clang_lto_flags_ok=no])
+    AC_LANG_POP([C++])
+
+    AS_IF([test "x$spike_clang_lto_flags_ok" = xyes], [
+      SPIKE_OPT_CFLAGS="-O3 -march=native -flto=thin"
+      SPIKE_OPT_LDFLAGS="-flto=thin"
+    ], [
+      AC_MSG_WARN([Clang ThinLTO flags are unsupported; continuing without the optimized build profile])
+    ])
+  ], [
+    AC_MSG_WARN([the selected compilers are not Clang; continuing without the optimized build profile])
+  ])
+])
+
+AC_SUBST([SPIKE_OPT_CFLAGS])
+AC_SUBST([SPIKE_OPT_LDFLAGS])
 
 #-------------------------------------------------------------------------
 # MCPPBS specific program checks

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,154 @@ m4_include(m4/ax_boost_asio.m4)
 m4_include(m4/ax_boost_regex.m4)
 
 #-------------------------------------------------------------------------
+# Build profiles
+#-------------------------------------------------------------------------
+
+AC_ARG_ENABLE([clang-lto],
+  [AS_HELP_STRING([--enable-clang-lto@<:@=VERSION@:>@],
+    [prefer an optimized host-native Clang ThinLTO build; VERSION selects LLVM tools (default: auto-detect version 21)])],
+  [enable_clang_lto=$enableval],
+  [enable_clang_lto=auto])
+
+case "$enable_clang_lto" in
+  auto)
+    spike_llvm_suffix=-21
+    spike_clang_lto_required=no
+    ;;
+  yes)
+    spike_llvm_suffix=-21
+    spike_clang_lto_required=yes
+    ;;
+  no)
+    spike_clang_lto_required=no
+    ;;
+  *[[!0-9]]*|'')
+    AC_MSG_ERROR([--enable-clang-lto accepts only a numeric LLVM version])
+    ;;
+  *)
+    spike_llvm_suffix="-$enable_clang_lto"
+    spike_clang_lto_required=yes
+    ;;
+esac
+
+spike_use_clang_lto=no
+
+AS_IF([test "x$enable_clang_lto" != xno], [
+  spike_clang_cc=clang$spike_llvm_suffix
+  spike_clang_cxx=clang++$spike_llvm_suffix
+  spike_clang_ar=llvm-ar$spike_llvm_suffix
+  spike_clang_ranlib=llvm-ranlib$spike_llvm_suffix
+  spike_clang_ld=ld.lld$spike_llvm_suffix
+
+  AS_IF([test "x$enable_clang_lto" = xauto && test "x$build" != "x$host"], [
+    AC_MSG_NOTICE([cross-compiling; skipping automatic Clang ThinLTO selection])
+  ], [
+    AS_IF([test "x$enable_clang_lto" = xauto &&
+           { test -n "${CC-}" || test -n "${CXX-}" ||
+             test -n "${AR-}" || test -n "${RANLIB-}"; }], [
+      AC_MSG_NOTICE([compiler tools were supplied; skipping automatic Clang ThinLTO selection])
+    ], [
+      CC=${CC:-$spike_clang_cc}
+      CXX=${CXX:-$spike_clang_cxx}
+      AR=${AR:-$spike_clang_ar}
+      RANLIB=${RANLIB:-$spike_clang_ranlib}
+
+      spike_missing_llvm_tools=
+      for spike_llvm_tool in "$CC" "$CXX" "$AR" "$RANLIB" \
+                             "$spike_clang_ld"; do
+        if command -v "$spike_llvm_tool" >/dev/null 2>&1 &&
+           "$spike_llvm_tool" --version >/dev/null 2>&1; then
+          :
+        else
+          spike_missing_llvm_tools="$spike_missing_llvm_tools $spike_llvm_tool"
+        fi
+      done
+
+      AS_IF([test -z "$spike_missing_llvm_tools"], [
+        spike_clang_ld_path=`command -v "$spike_clang_ld"`
+        spike_clang_ld_flag="--ld-path=$spike_clang_ld_path"
+
+        AC_MSG_CHECKING([whether the Clang ThinLTO toolchain can build a C++ program])
+        cat > conftest.c <<'_ACEOF'
+int spike_lto_probe(void) { return 0; }
+_ACEOF
+        cat > conftest.cpp <<'_ACEOF'
+#include <thread>
+extern "C" int spike_lto_probe(void);
+static void spike_thread_probe(void) {}
+int main(void) {
+  std::thread thread(spike_thread_probe);
+  thread.join();
+  return spike_lto_probe();
+}
+_ACEOF
+        spike_try_clang_lto ()
+        {
+          rm -f conftest conftest.o conftest.a
+          if test -n "$spike_clang_gcc_flag"; then
+            "$CC" "$spike_clang_gcc_flag" -O3 -march=native -flto=thin \
+              -c conftest.c -o conftest.o >/dev/null 2>&1 &&
+            "$AR" cr conftest.a conftest.o >/dev/null 2>&1 &&
+            "$RANLIB" conftest.a >/dev/null 2>&1 &&
+            "$CXX" "$spike_clang_gcc_flag" -O3 -march=native -flto=thin \
+              "$spike_clang_ld_flag" -pthread conftest.cpp conftest.a \
+              -o conftest >/dev/null 2>&1
+          else
+            "$CC" -O3 -march=native -flto=thin \
+              -c conftest.c -o conftest.o >/dev/null 2>&1 &&
+            "$AR" cr conftest.a conftest.o >/dev/null 2>&1 &&
+            "$RANLIB" conftest.a >/dev/null 2>&1 &&
+            "$CXX" -O3 -march=native -flto=thin "$spike_clang_ld_flag" \
+              -pthread conftest.cpp conftest.a -o conftest >/dev/null 2>&1
+          fi
+        }
+
+        spike_clang_gcc_flag=
+        spike_clang_probe_ok=no
+        AS_IF([spike_try_clang_lto], [
+          spike_clang_probe_ok=yes
+        ])
+
+        AS_IF([test "x$spike_clang_probe_ok" = xno && command -v g++ >/dev/null 2>&1], [
+          spike_system_libstdcxx=`g++ -print-file-name=libstdc++.so 2>/dev/null`
+          AS_IF([test -f "$spike_system_libstdcxx"], [
+            spike_system_gcc_dir=${spike_system_libstdcxx%/*}
+            spike_clang_gcc_flag="--gcc-install-dir=$spike_system_gcc_dir"
+            AS_IF([spike_try_clang_lto], [
+              spike_clang_probe_ok="yes, using $spike_system_gcc_dir"
+            ])
+          ])
+        ])
+        rm -f conftest conftest.c conftest.cpp conftest.o conftest.a
+        AC_MSG_RESULT([$spike_clang_probe_ok])
+
+        AS_IF([test "x$spike_clang_probe_ok" != xno], [
+          AS_IF([test -n "$spike_clang_gcc_flag"], [
+            CC="$CC $spike_clang_gcc_flag"
+            CXX="$CXX $spike_clang_gcc_flag"
+          ])
+          spike_use_clang_lto=yes
+        ], [
+          AS_IF([test "x$spike_clang_lto_required" = xyes], [
+            AC_MSG_ERROR([the requested Clang ThinLTO toolchain cannot build and link a C++ program])
+          ], [
+            AC_MSG_WARN([Clang ThinLTO toolchain is unusable; falling back to the default toolchain])
+            unset CC CXX AR RANLIB
+          ])
+        ])
+      ], [
+        AS_IF([test "x$spike_clang_lto_required" = xyes], [
+          AC_MSG_ERROR([required Clang ThinLTO tools unavailable:$spike_missing_llvm_tools])
+        ], [
+          AC_MSG_WARN([Clang ThinLTO tools unavailable:$spike_missing_llvm_tools; falling back to the default toolchain])
+          unset CC CXX AR RANLIB
+        ])
+      ])
+    ])
+  ])
+])
+
+#-------------------------------------------------------------------------
 # Checks for programs
 #-------------------------------------------------------------------------
 
@@ -65,6 +213,17 @@ AS_IF([test x"$DTC" == xno],AC_MSG_ERROR([device-tree-compiler not found]))
 AC_DEFINE_UNQUOTED(DTC, ["dtc"], [Executable name of device-tree-compiler])
 
 AC_C_BIGENDIAN
+
+SPIKE_OPT_CFLAGS=
+SPIKE_OPT_LDFLAGS=
+
+AS_IF([test "x$spike_use_clang_lto" = xyes], [
+  SPIKE_OPT_CFLAGS="-O3 -march=native -flto=thin"
+  SPIKE_OPT_LDFLAGS="-flto=thin $spike_clang_ld_flag"
+])
+
+AC_SUBST([SPIKE_OPT_CFLAGS])
+AC_SUBST([SPIKE_OPT_LDFLAGS])
 
 #-------------------------------------------------------------------------
 # MCPPBS specific program checks

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1743,6 +1743,10 @@ void vector_csr_t::write_raw(const reg_t val) noexcept {
     log_write();
 }
 
+void vector_csr_t::write_without_logging(const reg_t val) noexcept {
+  vector_csr_t::unlogged_write(val);
+}
+
 bool vector_csr_t::unlogged_write(const reg_t val) noexcept {
   if (mask == 0) return false;
   STATE.sstatus->dirty(SSTATUS_VS);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1747,6 +1747,10 @@ void vector_csr_t::write_raw(const reg_t val) noexcept {
     log_write();
 }
 
+void vector_csr_t::write_without_logging(const reg_t val) noexcept {
+  vector_csr_t::unlogged_write(val);
+}
+
 bool vector_csr_t::unlogged_write(const reg_t val) noexcept {
   if (mask == 0) return false;
   STATE.sstatus->dirty(SSTATUS_VS);

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -789,6 +789,8 @@ class vector_csr_t: public basic_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
   // Write without regard to mask, and without touching mstatus.VS
   void write_raw(const reg_t val) noexcept;
+  // Internal write for instruction implementations with commit logging disabled.
+  void write_without_logging(const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -789,6 +789,17 @@ class vector_csr_t: public basic_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
   // Write without regard to mask, and without touching mstatus.VS
   void write_raw(const reg_t val) noexcept;
+  // Internal write for instruction implementations with commit logging disabled.
+  void write_without_logging(const reg_t val) noexcept;
+  // Internal write for instruction implementations with a compile-time-known
+  // commit logging mode.
+  template <bool log>
+  void write_internal(const reg_t val) noexcept {
+    if constexpr (log)
+      write(val);
+    else
+      write_without_logging(val);
+  }
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -41,7 +41,9 @@
     if (DECODE_MACRO_USAGE_LOGGED) STATE.log_reg_write[((reg) << 4) | 1] = wdata; \
     DO_WRITE_FREG(reg, wdata); \
   })
-#define WRITE_VSTATUS STATE.log_reg_write[3] = {0, 0};
+#define WRITE_VSTATUS do { \
+    if (DECODE_MACRO_USAGE_LOGGED) STATE.log_reg_write[3] = {0, 0}; \
+  } while (0)
 
 /* the value parameter needs to be evaluated before writing to the registers */
 #define WRITE_REG_PAIR(reg, value) \

--- a/riscv/insn_template.cc
+++ b/riscv/insn_template.cc
@@ -6,6 +6,7 @@
 #define DECODE_MACRO_USAGE_LOGGED 0
 
 #define PROLOGUE \
+  [[maybe_unused]] constexpr bool log = DECODE_MACRO_USAGE_LOGGED; \
   reg_t npc = sext_xlen(pc + insn_length(OPCODE)); \
   if (!p->extension_enabled(EXT_ZCA)) assume(insn_length(OPCODE) % 4 == 0)
 

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -12,16 +12,16 @@ VI_GENERAL_LOOP_BASE
   if (P.VU.mask_elt(rs1_num, i)) {
     switch (sew) {
     case e8:
-      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
+      P.VU.elt<uint8_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint8_t>(rs2_num, i);
       break;
     case e16:
-      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
+      P.VU.elt<uint16_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint16_t>(rs2_num, i);
       break;
     case e32:
-      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
+      P.VU.elt<uint32_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint32_t>(rs2_num, i);
       break;
     default:
-      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
+      P.VU.elt<uint64_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint64_t>(rs2_num, i);
       break;
     }
 

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -12,16 +12,16 @@ VI_GENERAL_LOOP_BASE
   if (P.VU.mask_elt(rs1_num, i)) {
     switch (sew) {
     case e8:
-      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
+      P.VU.elt<uint8_t>(rd_num, pos, log) = P.VU.elt<uint8_t>(rs2_num, i);
       break;
     case e16:
-      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
+      P.VU.elt<uint16_t>(rd_num, pos, log) = P.VU.elt<uint16_t>(rs2_num, i);
       break;
     case e32:
-      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
+      P.VU.elt<uint32_t>(rd_num, pos, log) = P.VU.elt<uint32_t>(rs2_num, i);
       break;
     default:
-      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
+      P.VU.elt<uint64_t>(rd_num, pos, log) = P.VU.elt<uint64_t>(rs2_num, i);
       break;
     }
 

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -10,22 +10,22 @@ VI_LOOP_BASE
   case e8: {
     auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
     //if (i > 255) continue;
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    P.VU.elt<uint8_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
     break;
   }
   case e16: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
     break;
   }
   case e32: {
     auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
     break;
   }
   default: {
     auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
     break;
   }
   }

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -10,22 +10,22 @@ VI_LOOP_BASE
   case e8: {
     auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
     //if (i > 255) continue;
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    P.VU.elt<uint8_t>(rd_num, i, log) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
     break;
   }
   case e16: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    P.VU.elt<uint16_t>(rd_num, i, log) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
     break;
   }
   case e32: {
     auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    P.VU.elt<uint32_t>(rd_num, i, log) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
     break;
   }
   default: {
     auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    P.VU.elt<uint64_t>(rd_num, i, log) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
     break;
   }
   }

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -7,6 +7,13 @@
 #include "zvbdot.h"
 #include <functional>
 
+#define WRITE_VSTART(value) do { \
+  if constexpr (DECODE_MACRO_USAGE_LOGGED) \
+    P.VU.vstart->write(value); \
+  else \
+    P.VU.vstart->write_without_logging(value); \
+} while (0)
+
 //
 // vector: masking skip helper
 //
@@ -240,7 +247,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
  }
 
 #define VECTOR_END \
-  P.VU.vstart->write(0)
+  WRITE_VSTART(0)
 
 #define VI_LOOP_END \
   VI_LOOP_END_BASE \
@@ -329,61 +336,61 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // vector: integer and masking operand access helper
 //
 #define VXI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type simm5 = (type_sew_t<x>::type)insn.v_simm5();
 
 #define VV_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define V_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VX_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VI_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type UNUSED zimm5 = (type_usew_t<x>::type)insn.v_zimm5(); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VV_PARAMS(x) \
-  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define V_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_PARAMS(x) \
-  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define XV_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, RS1);
 
 #define VV_SU_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_SU_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
@@ -411,27 +418,27 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_XI_SLIDEDOWN_PARAMS(x, off) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i + off);
 
 #define VI_XI_SLIDEUP_PARAMS(x, offset) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i - offset);
 
 #define VI_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto zimm5 = (type_usew_t<sew1>::type)insn.v_zimm5();
 
 #define VX_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto rs1 = (type_sew_t<sew1>::type)RS1;
 
 #define VV_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<sew1>::type>(rs1_num, i);
@@ -449,15 +456,15 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto UNUSED rs1 = (type_sew_t<x>::type)RS1; \
   auto UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define VV_WITH_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define VFP_V_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VV_CMP_PARAMS(width) \
@@ -465,7 +472,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VV_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   VFP_VV_CMP_PARAMS(width)
 
 #define VFP_VF_CMP_PARAMS(width) \
@@ -473,20 +480,20 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   float##width##_t UNUSED vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VF_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   VFP_VF_CMP_PARAMS(width)
 
 #define CVT_FP_TO_FP_PARAMS(from_width, to_width) \
   auto vs2 = P.VU.elt<float##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define CVT_INT_TO_FP_PARAMS(from_width, to_width, sign) \
   auto vs2 = P.VU.elt<sign##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define CVT_FP_TO_INT_PARAMS(from_width, to_width, sign) \
   auto vs2 = P.VU.elt<float##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<sign##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<sign##to_width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 //
 // vector: integer and masking operation loop
@@ -984,19 +991,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign##16_t)(sign##8_t)var0 op0 (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign##32_t)(sign##16_t)var0 op0 (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign##64_t)(sign##32_t)var0 op0 (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1006,19 +1013,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op((sign##16_t)(sign##8_t)var0, (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op((sign##32_t)(sign##16_t)var0, (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op((sign##64_t)(sign##32_t)var0, (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1028,19 +1035,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign_d##16_t UNUSED vd_w = P.VU.elt<sign_d##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign_1##16_t)(sign_1##8_t)var0 op0 (sign_2##16_t)(sign_2##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign_d##32_t UNUSED vd_w = P.VU.elt<sign_d##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign_1##32_t)(sign_1##16_t)var0 op0 (sign_2##32_t)(sign_2##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign_d##64_t UNUSED vd_w = P.VU.elt<sign_d##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign_1##64_t)(sign_1##32_t)var0 op0 (sign_2##64_t)(sign_2##32_t)var1) + var2; \
     } \
     break; \
@@ -1049,19 +1056,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_WIDE_WVX_OP(var0, op0, sign) \
   switch (P.VU.vsew) { \
   case e8: { \
-    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, true); \
+    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
     sign##16_t vs2_w = P.VU.elt<sign##16_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##16_t)(sign##8_t)var0; \
     } \
     break; \
   case e16: { \
-    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, true); \
+    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
     sign##32_t vs2_w = P.VU.elt<sign##32_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##32_t)(sign##16_t)var0; \
     } \
     break; \
   default: { \
-    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, true); \
+    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
     sign##64_t vs2_w = P.VU.elt<sign##64_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##64_t)(sign##32_t)var0; \
     } \
@@ -1245,11 +1252,11 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = MMU.load<elt_width##_t>( \
         baseAddr + (stride) + (offset) * sizeof(elt_width##_t)); \
-      P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, true) = val; \
+      P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = val; \
     } \
   } \
   VECTOR_END;
@@ -1283,23 +1290,23 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
         case e8: \
-          P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
             MMU.load<uint8_t>(baseAddr + index + fn * 1); \
           break; \
         case e16: \
-          P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
             MMU.load<uint16_t>(baseAddr + index + fn * 2); \
           break; \
         case e32: \
-          P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
             MMU.load<uint32_t>(baseAddr + index + fn * 4); \
           break; \
         default: \
-          P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
             MMU.load<uint64_t>(baseAddr + index + fn * 8); \
           break; \
       } \
@@ -1316,7 +1323,7 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = P.VU.elt<elt_width##_t>(vs3 + fn * emul, vreg_inx); \
       MMU.store<elt_width##_t>( \
@@ -1337,7 +1344,7 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
       case e8: \
@@ -1379,7 +1386,7 @@ VI_VX_ULOOP({ \
           baseAddr + (i * nf + fn) * sizeof(elt_width##_t)); \
       } catch (trap_t& t) { \
         if (i == 0) { \
-          P.VU.vstart->write(0); /* dirty VS */ \
+          WRITE_VSTART(0); /* dirty VS */ \
           throw; /* Only take exception on zeroth element */ \
         } \
         /* Reduce VL if an exception occurs on a later element */ \
@@ -1387,7 +1394,7 @@ VI_VX_ULOOP({ \
         P.VU.vl->write_raw(i); \
         break; \
       } \
-      p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, true) = val; \
+      p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = val; \
     } \
     \
     if (early_stop) { \
@@ -1406,9 +1413,9 @@ VI_VX_ULOOP({ \
   const reg_t elt_per_reg = P.VU.vlenb / sizeof(elt_width ## _t); \
   const reg_t size = len * elt_per_reg; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
-    P.VU.elt<elt_width ## _t>(vd, i, true) = val; \
+    P.VU.elt<elt_width ## _t>(vd, i, DECODE_MACRO_USAGE_LOGGED) = val; \
   } \
   VECTOR_END;
 
@@ -1420,7 +1427,7 @@ VI_VX_ULOOP({ \
   require_align(vs3, len); \
   const reg_t size = len * P.VU.vlenb; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     auto val = P.VU.elt<uint8_t>(vs3, i); \
     MMU.store<uint8_t>(baseAddr + i, val); \
   } \
@@ -1447,22 +1454,22 @@ VI_VX_ULOOP({ \
   reg_t pat = (((P.VU.vsew >> 3) << 4) | from >> 3); \
     switch (pat) { \
       case 0x21: \
-        P.VU.elt<type##16_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x41: \
-        P.VU.elt<type##32_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x81: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x42: \
-        P.VU.elt<type##32_t>(rd_num, i, true) = P.VU.elt<type##16_t>(rs2_num, i); \
+        P.VU.elt<type##32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##16_t>(rs2_num, i); \
         break; \
       case 0x82: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##16_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##16_t>(rs2_num, i); \
         break; \
       case 0x84: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##32_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##32_t>(rs2_num, i); \
         break; \
       default: \
         break; \
@@ -1548,9 +1555,9 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint16_t>(rd_num, 0, true) = defaultNaNF16UI; \
+              P.VU.elt<uint16_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = defaultNaNF16UI; \
             } else { \
-              P.VU.elt<uint16_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint16_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
             } \
           } \
           break; \
@@ -1561,9 +1568,9 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint32_t>(rd_num, 0, true) = defaultNaNF32UI; \
+              P.VU.elt<uint32_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = defaultNaNF32UI; \
             } else { \
-              P.VU.elt<uint32_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint32_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
             } \
           } \
           break; \
@@ -1574,15 +1581,15 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint64_t>(rd_num, 0, true) = defaultNaNF64UI; \
+              P.VU.elt<uint64_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = defaultNaNF64UI; \
             } else { \
-              P.VU.elt<uint64_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint64_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
             } \
           } \
           break; \
       } \
     } else { \
-      P.VU.elt<type_sew_t<x>::type>(rd_num, 0, true) = vd_0.v; \
+      P.VU.elt<type_sew_t<x>::type>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
     } \
   }
 
@@ -1827,7 +1834,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa_or_zvfh; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
       float32_t rs1 = P.VU.altfmt ? bf16_to_f32(FRS1_BF) \
@@ -1837,7 +1844,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t rs1 = f32_to_f64(FRS1_F); \
       BODY32; \
@@ -1856,7 +1863,7 @@ VI_VX_ULOOP({ \
   VI_VFP_BF16_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)); \
       float32_t rs1 = bf16_to_f32(FRS1_BF); \
       BODY; \
@@ -1877,7 +1884,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<float16_t>(rs2_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
       float32_t vs1 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<float16_t>(rs1_num, i)) \
@@ -1887,7 +1894,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY32; \
@@ -1906,7 +1913,7 @@ VI_VX_ULOOP({ \
   VI_VFP_BF16_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)); \
       float32_t vs1 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs1_num, i)); \
       BODY; \
@@ -1927,7 +1934,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       float32_t rs1 = P.VU.altfmt ? bf16_to_f32(FRS1_BF) \
                                   :  f16_to_f32(FRS1_H); \
@@ -1936,7 +1943,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t rs1 = f32_to_f64(FRS1_F); \
       BODY32; \
@@ -1955,7 +1962,7 @@ VI_VX_ULOOP({ \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       float32_t vs1 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<bfloat16_t>(rs1_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs1_num, i)); \
@@ -1964,7 +1971,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY32; \
@@ -2252,7 +2259,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
     a[i] = P.VU.elt<a_t>(insn.rs1(), i); \
     b[i] = P.VU.elt<b_t>(insn.rs2(), i); \
   } \
-  auto& acc = P.VU.elt<c_t>(insn.rd(), 0, true); \
+  auto& acc = P.VU.elt<c_t>(insn.rd(), 0, DECODE_MACRO_USAGE_LOGGED); \
   acc = dot(a, b, acc); \
   set_fp_exceptions;
 
@@ -2274,7 +2281,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
       a[k] = P.VU.elt<a_t>(insn.rs1(), k); \
       b[k] = P.VU.elt<b_t>(vs2 + idx, k); \
     } \
-    auto& acc = P.VU.elt<c_t>(insn.rd(), i, true); \
+    auto& acc = P.VU.elt<c_t>(insn.rd(), i, DECODE_MACRO_USAGE_LOGGED); \
     acc = dot(a, b, acc); \
     set_fp_exceptions; \
   }

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -240,7 +240,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
  }
 
 #define VECTOR_END \
-  P.VU.vstart->write(0)
+  P.VU.vstart->write_internal<log>(0)
 
 #define VI_LOOP_END \
   VI_LOOP_END_BASE \
@@ -329,61 +329,61 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // vector: integer and masking operand access helper
 //
 #define VXI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type simm5 = (type_sew_t<x>::type)insn.v_simm5();
 
 #define VV_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define V_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VX_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VI_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type UNUSED zimm5 = (type_usew_t<x>::type)insn.v_zimm5(); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VV_PARAMS(x) \
-  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define V_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_PARAMS(x) \
-  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_sew_t<x>::type UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define XV_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, RS1);
 
 #define VV_SU_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_SU_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
@@ -411,27 +411,27 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_XI_SLIDEDOWN_PARAMS(x, off) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i + off);
 
 #define VI_XI_SLIDEUP_PARAMS(x, offset) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i - offset);
 
 #define VI_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, log); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto zimm5 = (type_usew_t<sew1>::type)insn.v_zimm5();
 
 #define VX_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, log); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto rs1 = (type_sew_t<sew1>::type)RS1;
 
 #define VV_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, log); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<sew1>::type>(rs1_num, i);
@@ -449,15 +449,15 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto UNUSED rs1 = (type_sew_t<x>::type)RS1; \
   auto UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log);
 
 #define VV_WITH_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, log);
 
 #define VFP_V_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, log); \
   float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VV_CMP_PARAMS(width) \
@@ -465,7 +465,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VV_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, log); \
   VFP_VV_CMP_PARAMS(width)
 
 #define VFP_VF_CMP_PARAMS(width) \
@@ -473,20 +473,20 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   float##width##_t UNUSED vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VF_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, log); \
   VFP_VF_CMP_PARAMS(width)
 
 #define CVT_FP_TO_FP_PARAMS(from_width, to_width) \
   auto vs2 = P.VU.elt<float##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, log);
 
 #define CVT_INT_TO_FP_PARAMS(from_width, to_width, sign) \
   auto vs2 = P.VU.elt<sign##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, log);
 
 #define CVT_FP_TO_INT_PARAMS(from_width, to_width, sign) \
   auto vs2 = P.VU.elt<float##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<sign##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<sign##to_width##_t>(rd_num, i, log);
 
 //
 // vector: integer and masking operation loop
@@ -984,19 +984,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, log) = \
       op1((sign##16_t)(sign##8_t)var0 op0 (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, log) = \
       op1((sign##32_t)(sign##16_t)var0 op0 (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, log) = \
       op1((sign##64_t)(sign##32_t)var0 op0 (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1006,19 +1006,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, log) = \
       op((sign##16_t)(sign##8_t)var0, (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, log) = \
       op((sign##32_t)(sign##16_t)var0, (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, log) = \
       op((sign##64_t)(sign##32_t)var0, (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1028,19 +1028,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign_d##16_t UNUSED vd_w = P.VU.elt<sign_d##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, log) = \
       op1((sign_1##16_t)(sign_1##8_t)var0 op0 (sign_2##16_t)(sign_2##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign_d##32_t UNUSED vd_w = P.VU.elt<sign_d##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, log) = \
       op1((sign_1##32_t)(sign_1##16_t)var0 op0 (sign_2##32_t)(sign_2##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign_d##64_t UNUSED vd_w = P.VU.elt<sign_d##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, log) = \
       op1((sign_1##64_t)(sign_1##32_t)var0 op0 (sign_2##64_t)(sign_2##32_t)var1) + var2; \
     } \
     break; \
@@ -1049,19 +1049,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_WIDE_WVX_OP(var0, op0, sign) \
   switch (P.VU.vsew) { \
   case e8: { \
-    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, true); \
+    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, log); \
     sign##16_t vs2_w = P.VU.elt<sign##16_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##16_t)(sign##8_t)var0; \
     } \
     break; \
   case e16: { \
-    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, true); \
+    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, log); \
     sign##32_t vs2_w = P.VU.elt<sign##32_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##32_t)(sign##16_t)var0; \
     } \
     break; \
   default: { \
-    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, true); \
+    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, log); \
     sign##64_t vs2_w = P.VU.elt<sign##64_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##64_t)(sign##32_t)var0; \
     } \
@@ -1245,11 +1245,11 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    P.VU.vstart->write(i); \
+    P.VU.vstart->write_internal<log>(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = MMU.load<elt_width##_t>( \
         baseAddr + (stride) + (offset) * sizeof(elt_width##_t)); \
-      P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, true) = val; \
+      P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, log) = val; \
     } \
   } \
   VECTOR_END;
@@ -1283,23 +1283,23 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    P.VU.vstart->write(i); \
+    P.VU.vstart->write_internal<log>(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
         case e8: \
-          P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, log) = \
             MMU.load<uint8_t>(baseAddr + index + fn * 1); \
           break; \
         case e16: \
-          P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, log) = \
             MMU.load<uint16_t>(baseAddr + index + fn * 2); \
           break; \
         case e32: \
-          P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, log) = \
             MMU.load<uint32_t>(baseAddr + index + fn * 4); \
           break; \
         default: \
-          P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, true) = \
+          P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, log) = \
             MMU.load<uint64_t>(baseAddr + index + fn * 8); \
           break; \
       } \
@@ -1316,7 +1316,7 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    P.VU.vstart->write(i); \
+    P.VU.vstart->write_internal<log>(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = P.VU.elt<elt_width##_t>(vs3 + fn * emul, vreg_inx); \
       MMU.store<elt_width##_t>( \
@@ -1337,7 +1337,7 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    P.VU.vstart->write(i); \
+    P.VU.vstart->write_internal<log>(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
       case e8: \
@@ -1379,7 +1379,7 @@ VI_VX_ULOOP({ \
           baseAddr + (i * nf + fn) * sizeof(elt_width##_t)); \
       } catch (trap_t& t) { \
         if (i == 0) { \
-          P.VU.vstart->write(0); /* dirty VS */ \
+          P.VU.vstart->write_internal<log>(0); /* dirty VS */ \
           throw; /* Only take exception on zeroth element */ \
         } \
         /* Reduce VL if an exception occurs on a later element */ \
@@ -1387,7 +1387,7 @@ VI_VX_ULOOP({ \
         P.VU.vl->write_raw(i); \
         break; \
       } \
-      p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, true) = val; \
+      p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, log) = val; \
     } \
     \
     if (early_stop) { \
@@ -1406,9 +1406,9 @@ VI_VX_ULOOP({ \
   const reg_t elt_per_reg = P.VU.vlenb / sizeof(elt_width ## _t); \
   const reg_t size = len * elt_per_reg; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    P.VU.vstart->write(i); \
+    P.VU.vstart->write_internal<log>(i); \
     auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
-    P.VU.elt<elt_width ## _t>(vd, i, true) = val; \
+    P.VU.elt<elt_width ## _t>(vd, i, log) = val; \
   } \
   VECTOR_END;
 
@@ -1420,7 +1420,7 @@ VI_VX_ULOOP({ \
   require_align(vs3, len); \
   const reg_t size = len * P.VU.vlenb; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    P.VU.vstart->write(i); \
+    P.VU.vstart->write_internal<log>(i); \
     auto val = P.VU.elt<uint8_t>(vs3, i); \
     MMU.store<uint8_t>(baseAddr + i, val); \
   } \
@@ -1447,22 +1447,22 @@ VI_VX_ULOOP({ \
   reg_t pat = (((P.VU.vsew >> 3) << 4) | from >> 3); \
     switch (pat) { \
       case 0x21: \
-        P.VU.elt<type##16_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##16_t>(rd_num, i, log) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x41: \
-        P.VU.elt<type##32_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##32_t>(rd_num, i, log) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x81: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, log) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x42: \
-        P.VU.elt<type##32_t>(rd_num, i, true) = P.VU.elt<type##16_t>(rs2_num, i); \
+        P.VU.elt<type##32_t>(rd_num, i, log) = P.VU.elt<type##16_t>(rs2_num, i); \
         break; \
       case 0x82: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##16_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, log) = P.VU.elt<type##16_t>(rs2_num, i); \
         break; \
       case 0x84: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##32_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, log) = P.VU.elt<type##32_t>(rs2_num, i); \
         break; \
       default: \
         break; \
@@ -1548,9 +1548,9 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint16_t>(rd_num, 0, true) = defaultNaNF16UI; \
+              P.VU.elt<uint16_t>(rd_num, 0, log) = defaultNaNF16UI; \
             } else { \
-              P.VU.elt<uint16_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint16_t>(rd_num, 0, log) = vd_0.v; \
             } \
           } \
           break; \
@@ -1561,9 +1561,9 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint32_t>(rd_num, 0, true) = defaultNaNF32UI; \
+              P.VU.elt<uint32_t>(rd_num, 0, log) = defaultNaNF32UI; \
             } else { \
-              P.VU.elt<uint32_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint32_t>(rd_num, 0, log) = vd_0.v; \
             } \
           } \
           break; \
@@ -1574,15 +1574,15 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint64_t>(rd_num, 0, true) = defaultNaNF64UI; \
+              P.VU.elt<uint64_t>(rd_num, 0, log) = defaultNaNF64UI; \
             } else { \
-              P.VU.elt<uint64_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint64_t>(rd_num, 0, log) = vd_0.v; \
             } \
           } \
           break; \
       } \
     } else { \
-      P.VU.elt<type_sew_t<x>::type>(rd_num, 0, true) = vd_0.v; \
+      P.VU.elt<type_sew_t<x>::type>(rd_num, 0, log) = vd_0.v; \
     } \
   }
 
@@ -1827,7 +1827,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa_or_zvfh; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, log); \
       float32_t vs2 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
       float32_t rs1 = P.VU.altfmt ? bf16_to_f32(FRS1_BF) \
@@ -1837,7 +1837,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, log); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t rs1 = f32_to_f64(FRS1_F); \
       BODY32; \
@@ -1856,7 +1856,7 @@ VI_VX_ULOOP({ \
   VI_VFP_BF16_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, log); \
       float32_t vs2 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)); \
       float32_t rs1 = bf16_to_f32(FRS1_BF); \
       BODY; \
@@ -1877,7 +1877,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, log); \
       float32_t vs2 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<float16_t>(rs2_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
       float32_t vs1 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<float16_t>(rs1_num, i)) \
@@ -1887,7 +1887,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, log); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY32; \
@@ -1906,7 +1906,7 @@ VI_VX_ULOOP({ \
   VI_VFP_BF16_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, log); \
       float32_t vs2 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)); \
       float32_t vs1 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs1_num, i)); \
       BODY; \
@@ -1927,7 +1927,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, log); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       float32_t rs1 = P.VU.altfmt ? bf16_to_f32(FRS1_BF) \
                                   :  f16_to_f32(FRS1_H); \
@@ -1936,7 +1936,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, log); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t rs1 = f32_to_f64(FRS1_F); \
       BODY32; \
@@ -1955,7 +1955,7 @@ VI_VX_ULOOP({ \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, log); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       float32_t vs1 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<bfloat16_t>(rs1_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs1_num, i)); \
@@ -1964,7 +1964,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, log); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY32; \
@@ -2253,7 +2253,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
       a[i] = P.VU.elt<a_t>(insn.rs1(), i); \
       b[i] = P.VU.elt<b_t>(insn.rs2(), i); \
     } \
-    auto& acc = P.VU.elt<c_t>(insn.rd(), 0, true); \
+    auto& acc = P.VU.elt<c_t>(insn.rd(), 0, log); \
     acc = dot(a, b, acc); \
     set_fp_exceptions; \
   }
@@ -2277,7 +2277,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
         a[k] = P.VU.elt<a_t>(insn.rs1(), k); \
         b[k] = P.VU.elt<b_t>(vs2 + idx, k); \
       } \
-      auto& acc = P.VU.elt<c_t>(insn.rd(), i, true); \
+      auto& acc = P.VU.elt<c_t>(insn.rd(), i, log); \
       acc = dot(a, b, acc); \
       set_fp_exceptions; \
     } \

--- a/riscv/zvzip_ext_macros.h
+++ b/riscv/zvzip_ext_macros.h
@@ -44,7 +44,7 @@
 
 #define VI_VZIP_VV_LOOP_END \
   } \
-  P.VU.vstart->write(0);
+  WRITE_VSTART(0);
 
 #define VI_VZIP_VV_LOOP(VS1_IDX, VS2_IDX) \
   VI_VZIP_VV_CHECK \

--- a/riscv/zvzip_ext_macros.h
+++ b/riscv/zvzip_ext_macros.h
@@ -44,7 +44,7 @@
 
 #define VI_VZIP_VV_LOOP_END \
   } \
-  P.VU.vstart->write(0);
+  P.VU.vstart->write_internal<log>(0);
 
 #define VI_VZIP_VV_LOOP(VS1_IDX, VS2_IDX) \
   VI_VZIP_VV_CHECK \


### PR DESCRIPTION
Spike is faster when compiled with Clang 21 and ThinLTO. The build system is updated to prefer that configuration for native builds when it is available, with a fallback to the normal GCC build.

The vector fast-path change uses each generated wrapper's compile-time logging mode to bypass status, CSR, and destination logging when commit logging is disabled. Logged wrappers retain architectural commit tracking.

| Benchmark | Speedup |
|---|---:|
| `vector_mix` | 38.55% |
| `vector_mask_mix` | 31.06% |
| `branch_mix` | 7.92% |
| `int_mix` | 7.08% |

These are isolated measurements of the vector fast-path commit using 16 paired runs on an AMD EPYC 7F52 host.

This PR intentionally contains two commits: one build-system commit and one vector fast-path commit.
The Clang 21 + ThinLTO build substantially improves several scalar, FPU, and CSR lanes, but regresses the vector workloads. So this PR pairs it with a vector fast-path change that skips logging work when commit logging is already disabled. Logged execution remains unchanged. In isolated measurements, this change improved vector_mix by 38.55% and vector_mask_mix by 31.06%, offsetting the main Clang + ThinLTO regressions.
