### PR TITLE
rocc: enable custom0..3 dispatch for rv32

### DIFF
--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -34,10 +34,10 @@ customX(3)
 std::vector<insn_desc_t> rocc_t::get_instructions(const processor_t &)
 {
   std::vector<insn_desc_t> insns = {
-    {0x0b, 0x7f, &::illegal_instruction, c0, &::illegal_instruction, c0, &::illegal_instruction, c0, &::illegal_instruction, c0},
-    {0x2b, 0x7f, &::illegal_instruction, c1, &::illegal_instruction, c1, &::illegal_instruction, c1, &::illegal_instruction, c1},
-    {0x5b, 0x7f, &::illegal_instruction, c2, &::illegal_instruction, c2, &::illegal_instruction, c2, &::illegal_instruction, c2},
-    {0x7b, 0x7f, &::illegal_instruction, c3, &::illegal_instruction, c3, &::illegal_instruction, c0, &::illegal_instruction, c3}};
+    {0x0b, 0x7f, c0, c0, c0, c0, c0, c0, c0, c0},
+    {0x2b, 0x7f, c1, c1, c1, c1, c1, c1, c1, c1},
+    {0x5b, 0x7f, c2, c2, c2, c2, c2, c2, c2, c2},
+    {0x7b, 0x7f, c3, c3, c3, c3, c3, c3, c3, c3}};
   return insns;
 }
 


### PR DESCRIPTION
## Problem

`rocc_t::get_instructions()` registers custom0..3 with
`illegal_instruction` in all rv32 slots (`fast_rv32i`, `fast_rv32e`,
`logged_rv32i`, `logged_rv32e`). A rv32 hart executing any custom0..3
instruction traps with illegal instruction instead of dispatching to
the registered `rocc_t` extension.

## Root cause

The rv32 slots were `&::illegal_instruction` from the initial RoCC
commit. When the struct grew rv32e and logged variants, they were
mechanically copied with the same pattern — never fixing the original
omission.

## Fix

The `c0..c3` handlers generated by `customX` are ISA-width-agnostic:
`RS1`/`RS2`/`WRITE_RD` resolve correctly for both rv32 and rv64.
Wire all four rv32 slot pairs to the same handlers as rv64.

Also fixes a copy-paste error: `custom3`'s `logged_rv64e` slot was
accidentally set to `c0` instead of `c3`.