### PR TITLE
Mask off return-address MSB in cm.popret[z]

### DIFF
--- a/riscv/insns/cm_popret.h
+++ b/riscv/insns/cm_popret.h
@@ -1,2 +1,2 @@
 #include "cm_pop.h"
-set_pc(RA);
+set_pc(RA & ~reg_t(1));


### PR DESCRIPTION
Prevents an `abort()`.

Fixes #2383