### PR TITLE
cm.popret clear bit 0 of the return address

### DIFF
--- a/riscv/insns/cm_popret.h
+++ b/riscv/insns/cm_popret.h
@@ -1,2 +1,2 @@
 #include "cm_pop.h"
-set_pc(RA);
+set_pc(RA & ~reg_t(1));


### PR DESCRIPTION
Fixes the https://github.com/riscv-software-src/riscv-isa-sim/issues/2383