### PR TITLE
Raise exceptions correctly in a few load/store cases

### DIFF
--- a/riscv/insns/lb_aq.h
+++ b/riscv/insns/lb_aq.h
@@ -1,2 +1,2 @@
 require_extension(EXT_ZALASR);
-WRITE_RD(MMU.load_strict<int8_t>(RS1));
+WRITE_RD(MMU.load_acquire<int8_t>(RS1));

--- a/riscv/insns/ld_aq.h
+++ b/riscv/insns/ld_aq.h
@@ -1,3 +1,3 @@
 require_rv64;
 require_extension(EXT_ZALASR);
-WRITE_RD(MMU.load_strict<int64_t>(RS1));
+WRITE_RD(MMU.load_acquire<int64_t>(RS1));

--- a/riscv/insns/lh_aq.h
+++ b/riscv/insns/lh_aq.h
@@ -1,2 +1,2 @@
 require_extension(EXT_ZALASR);
-WRITE_RD(MMU.load_strict<int16_t>(RS1));
+WRITE_RD(MMU.load_acquire<int16_t>(RS1));

--- a/riscv/insns/lw_aq.h
+++ b/riscv/insns/lw_aq.h
@@ -1,2 +1,2 @@
 require_extension(EXT_ZALASR);
-WRITE_RD(MMU.load_strict<int32_t>(RS1));
+WRITE_RD(MMU.load_acquire<int32_t>(RS1));

--- a/riscv/insns/sb_rl.h
+++ b/riscv/insns/sb_rl.h
@@ -1,2 +1,2 @@
 require_extension(EXT_ZALASR);
-MMU.store_strict<uint8_t>(RS1, RS2);
+MMU.store_release<uint8_t>(RS1, RS2);

--- a/riscv/insns/sd_rl.h
+++ b/riscv/insns/sd_rl.h
@@ -1,3 +1,3 @@
 require_rv64;
 require_extension(EXT_ZALASR);
-MMU.store_strict<uint64_t>(RS1, RS2);
+MMU.store_release<uint64_t>(RS1, RS2);

--- a/riscv/insns/sh_rl.h
+++ b/riscv/insns/sh_rl.h
@@ -1,2 +1,2 @@
 require_extension(EXT_ZALASR);
-MMU.store_strict<uint16_t>(RS1, RS2);
+MMU.store_release<uint16_t>(RS1, RS2);

--- a/riscv/insns/sw_rl.h
+++ b/riscv/insns/sw_rl.h
@@ -1,2 +1,2 @@
 require_extension(EXT_ZALASR);
-MMU.store_strict<uint32_t>(RS1, RS2);
+MMU.store_release<uint32_t>(RS1, RS2);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -293,7 +293,7 @@ void mmu_t::load_slow_path(reg_t original_addr, std::size_t len,
     if (!is_misaligned_enabled())
       throw trap_load_address_misaligned(access_info.effective_virt, transformed_addr, 0, 0);
 
-    if (access_info.flags.lr)
+    if (access_info.flags.require_alignment)
       throw trap_load_access_fault(access_info.effective_virt, transformed_addr, 0, 0);
 
     reg_t len_page0 = std::min<reg_t>(len, PGSIZE - transformed_addr % PGSIZE);
@@ -354,14 +354,14 @@ void mmu_t::store_slow_path_intrapage(reg_t len, const uint8_t* bytes, mem_acces
 
 void mmu_t::store_slow_path(reg_t original_addr, std::size_t len,
     const std::uint8_t* bytes, xlate_flags_t xlate_flags,
-    bool actually_store, bool require_alignment)
+    bool actually_store)
 {
   if (likely(!xlate_flags.is_special_access())) {
     // Fast path for simple cases
     auto [tlb_hit, host_addr, paddr] = access_tlb(tlb_store, original_addr, TLB_FLAGS & ~TLB_CHECK_TRIGGERS);
     bool intrapage = (original_addr % PGSIZE) + len <= PGSIZE;
     bool aligned = (original_addr & (len - 1)) == 0;
-    bool misaligned_ok = !require_alignment && intrapage && is_misaligned_enabled();
+    bool misaligned_ok = intrapage && is_misaligned_enabled();
 
     if (likely(tlb_hit && (aligned || misaligned_ok))) {
       if (actually_store)
@@ -390,7 +390,7 @@ void mmu_t::store_slow_path(reg_t original_addr, std::size_t len,
     if (!is_misaligned_enabled())
       throw trap_store_address_misaligned(access_info.effective_virt, transformed_addr, 0, 0);
 
-    if (require_alignment)
+    if (access_info.flags.require_alignment)
       throw trap_store_access_fault(access_info.effective_virt, transformed_addr, 0, 0);
 
     reg_t len_page0 = std::min<reg_t>(len, PGSIZE - transformed_addr % PGSIZE);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -284,20 +284,22 @@ void mmu_t::load_slow_path(reg_t original_addr, std::size_t len,
     check_triggers(triggers::OPERATION_LOAD,
       transformed_addr, access_info.effective_virt, len);
 
+  if (access_info.flags.access_fault)
+    throw trap_load_access_fault(access_info.effective_virt, transformed_addr, 0, 0);
+
   if ((transformed_addr & (len - 1)) == 0) {
     load_slow_path_intrapage(len, bytes, access_info);
   } else {
-    bool gva = access_info.effective_virt;
     if (!is_misaligned_enabled())
-      throw trap_load_address_misaligned(gva, transformed_addr, 0, 0);
+      throw trap_load_address_misaligned(access_info.effective_virt, transformed_addr, 0, 0);
 
     if (access_info.flags.lr)
-      throw trap_load_access_fault(gva, transformed_addr, 0, 0);
+      throw trap_load_access_fault(access_info.effective_virt, transformed_addr, 0, 0);
 
     reg_t len_page0 = std::min<reg_t>(len, PGSIZE - transformed_addr % PGSIZE);
     load_slow_path_intrapage(len_page0, bytes, access_info);
     if (len_page0 != len) {
-      auto tail_access_info = generate_access_info(original_addr + len_page0, LOAD, xlate_flags);
+      auto tail_access_info = generate_access_info(original_addr + len_page0, LOAD, access_info.flags);
       load_slow_path_intrapage(len - len_page0, bytes + len_page0, tail_access_info);
     }
   }
@@ -381,18 +383,20 @@ void mmu_t::store_slow_path(reg_t original_addr, std::size_t len,
     }
   }
 
+  if (access_info.flags.access_fault)
+    throw trap_store_access_fault(access_info.effective_virt, transformed_addr, 0, 0);
+
   if (transformed_addr & (len - 1)) {
-    bool gva = access_info.effective_virt;
     if (!is_misaligned_enabled())
-      throw trap_store_address_misaligned(gva, transformed_addr, 0, 0);
+      throw trap_store_address_misaligned(access_info.effective_virt, transformed_addr, 0, 0);
 
     if (require_alignment)
-      throw trap_store_access_fault(gva, transformed_addr, 0, 0);
+      throw trap_store_access_fault(access_info.effective_virt, transformed_addr, 0, 0);
 
     reg_t len_page0 = std::min<reg_t>(len, PGSIZE - transformed_addr % PGSIZE);
     store_slow_path_intrapage(len_page0, bytes, access_info, actually_store);
     if (len_page0 != len) {
-      auto tail_access_info = generate_access_info(original_addr + len_page0, STORE, xlate_flags);
+      auto tail_access_info = generate_access_info(original_addr + len_page0, STORE, access_info.flags);
       store_slow_path_intrapage(len - len_page0, bytes + len_page0, tail_access_info, actually_store);
     }
   } else {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -144,9 +144,8 @@ public:
 
   template<typename T>
   T load_strict(reg_t addr) {
-    if ((addr & (sizeof(T) - 1)) != 0)
-      throw trap_load_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-    return load<T>(addr);
+    bool misaligned = addr % sizeof(T);
+    return load<T>(addr, {.require_alignment=misaligned});
   }
 
   template<typename T>
@@ -177,9 +176,8 @@ public:
 
   template<typename T>
   void store_strict(reg_t addr, T val) {
-    if ((addr & (sizeof(T) - 1)) != 0)
-      throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-    store<T>(addr, val);
+    bool misaligned = addr % sizeof(T);
+    store<T>(addr, val, {.require_alignment=misaligned});
   }
 
   // AMO/Zicbom faults should be reported as store faults

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -144,8 +144,7 @@ public:
 
   template<typename T>
   T load_acquire(reg_t addr) {
-    bool misaligned = addr % sizeof(T);
-    return load<T>(addr, {.require_alignment=misaligned});
+    return load<T>(addr, {.require_alignment=enforce_amo_alignment(addr, sizeof(T))});
   }
 
   template<typename T>
@@ -176,8 +175,7 @@ public:
 
   template<typename T>
   void store_release(reg_t addr, T val) {
-    bool misaligned = addr % sizeof(T);
-    store<T>(addr, val, {.require_alignment=misaligned});
+    store<T>(addr, val, {.require_alignment=enforce_amo_alignment(addr, sizeof(T))});
   }
 
   // AMO/Zicbom faults should be reported as store faults

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -72,9 +72,10 @@ struct xlate_flags_t {
   const bool ss_access : 1 {false};
   const bool clean_inval : 1 {false};
   const bool access_fault : 1 {false};
+  const bool require_alignment : 1 {false};
 
   bool is_special_access() const {
-    return forced_virt || hlvx || lr || ss_access || clean_inval || access_fault;
+    return forced_virt || hlvx || lr || ss_access || clean_inval || access_fault || require_alignment;
   }
 };
 
@@ -121,7 +122,7 @@ public:
 
   template<typename T>
   T load_reserved(reg_t addr) {
-    return load<T>(addr, {.lr = true});
+    return load<T>(addr, {.lr=true, .require_alignment=true});
   }
 
   template<typename T>
@@ -158,7 +159,7 @@ public:
       *(target_endian<T>*)host_addr = to_target(val);
     } else {
       target_endian<T> target_val = to_target(val);
-      store_slow_path(addr, sizeof(T), (const uint8_t*)&target_val, xlate_flags, true, false);
+      store_slow_path(addr, sizeof(T), (const uint8_t*)&target_val, xlate_flags, true);
     }
   }
 
@@ -200,14 +201,14 @@ public:
     if (proc->extension_enabled(EXT_ZAMA16B))
       return (addr / 16) != ((addr + size - 1) / 16);
 
-    return true;
+    return addr & (size - 1);
   }
 
   // template for functions that perform an atomic memory operation
   template<typename T, typename op>
   T amo(reg_t addr, op f) {
     convert_load_traps_to_store_traps({
-      store_slow_path(addr, sizeof(T), nullptr, {}, false, enforce_amo_alignment(addr, sizeof(T)));
+      store_slow_path(addr, sizeof(T), nullptr, {.require_alignment=enforce_amo_alignment(addr, sizeof(T))}, false);
       auto lhs = load<T>(addr);
       store<T>(addr, f(lhs));
       return lhs;
@@ -219,7 +220,7 @@ public:
   T ssamoswap(reg_t addr, reg_t value) {
     convert_load_traps_to_store_traps({
       bool misaligned = addr % sizeof(T);
-      store_slow_path(addr, sizeof(T), nullptr, {.ss_access=true, .access_fault=misaligned}, false, false);
+      store_slow_path(addr, sizeof(T), nullptr, {.ss_access=true, .access_fault=misaligned}, false);
       auto data = load<T>(addr, {.ss_access=true});
       store<T>(addr, value, {.ss_access=true});
       return data;
@@ -229,7 +230,7 @@ public:
   template<typename T>
   T amo_compare_and_swap(reg_t addr, T comp, T swap) {
     convert_load_traps_to_store_traps({
-      store_slow_path(addr, sizeof(T), nullptr, {}, false, enforce_amo_alignment(addr, sizeof(T)));
+      store_slow_path(addr, sizeof(T), nullptr, {.require_alignment=enforce_amo_alignment(addr, sizeof(T))}, false);
       auto lhs = load<T>(addr);
       if (lhs == comp)
         store<T>(addr, swap);
@@ -278,7 +279,7 @@ public:
   {
     if (vaddr & (size-1)) {
       // Raise either access fault or misaligned exception
-      store_slow_path(vaddr, size, nullptr, {}, false, true);
+      store_slow_path(vaddr, size, nullptr, {.require_alignment=true}, false);
     }
 
     auto [tlb_hit, _, paddr] = access_tlb(tlb_store, vaddr);
@@ -449,7 +450,7 @@ private:
   void perform_intrapage_load(reg_t vaddr, uintptr_t host_addr, reg_t paddr, reg_t len, uint8_t* bytes, xlate_flags_t xlate_flags);
 
   void store_slow_path(reg_t original_addr, std::size_t len, const std::uint8_t* bytes,
-    xlate_flags_t xlate_flags, bool actually_store, bool require_alignment);
+    xlate_flags_t xlate_flags, bool actually_store);
   void store_slow_path_intrapage(reg_t len, const uint8_t* bytes, mem_access_info_t access_info, bool actually_store);
   void perform_intrapage_store(reg_t vaddr, uintptr_t host_addr, reg_t paddr, reg_t len, const uint8_t* bytes, xlate_flags_t xlate_flags);
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -143,7 +143,7 @@ public:
   }
 
   template<typename T>
-  T load_strict(reg_t addr) {
+  T load_acquire(reg_t addr) {
     bool misaligned = addr % sizeof(T);
     return load<T>(addr, {.require_alignment=misaligned});
   }
@@ -175,7 +175,7 @@ public:
   }
 
   template<typename T>
-  void store_strict(reg_t addr, T val) {
+  void store_release(reg_t addr, T val) {
     bool misaligned = addr % sizeof(T);
     store<T>(addr, val, {.require_alignment=misaligned});
   }

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -71,9 +71,10 @@ struct xlate_flags_t {
   const bool lr : 1 {false};
   const bool ss_access : 1 {false};
   const bool clean_inval : 1 {false};
+  const bool access_fault : 1 {false};
 
   bool is_special_access() const {
-    return forced_virt || hlvx || lr || ss_access || clean_inval;
+    return forced_virt || hlvx || lr || ss_access || clean_inval || access_fault;
   }
 };
 
@@ -136,9 +137,8 @@ public:
   // shadow stack load
   template<typename T>
   T ss_load(reg_t addr) {
-    if ((addr & (sizeof(T) - 1)) != 0)
-      throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-    return load<T>(addr, {.ss_access=true});
+    bool misaligned = addr % sizeof(T);
+    return load<T>(addr, {.ss_access=true, .access_fault=misaligned});
   }
 
   template<typename T>
@@ -170,9 +170,8 @@ public:
   // shadow stack store
   template<typename T>
   void ss_store(reg_t addr, T val) {
-    if ((addr & (sizeof(T) - 1)) != 0)
-      throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-    store<T>(addr, val, {.ss_access=true});
+    bool misaligned = addr % sizeof(T);
+    store<T>(addr, val, {.ss_access=true, .access_fault=misaligned});
   }
 
   template<typename T>
@@ -219,7 +218,8 @@ public:
   template<typename T>
   T ssamoswap(reg_t addr, reg_t value) {
     convert_load_traps_to_store_traps({
-      store_slow_path(addr, sizeof(T), nullptr, {.ss_access=true}, false, true);
+      bool misaligned = addr % sizeof(T);
+      store_slow_path(addr, sizeof(T), nullptr, {.ss_access=true, .access_fault=misaligned}, false, false);
       auto data = load<T>(addr, {.ss_access=true});
       store<T>(addr, value, {.ss_access=true});
       return data;


### PR DESCRIPTION
- Always raise store access exceptions for shadow-stack accesses (never misaligned)
- Set cause register correctly for pointer-masked shadow-stack accesses
- Make load-acquire/store-release exception type match AMOs
- Respect Zama16b for load-acquire/store-release