### PR TITLE
Fix mip SEIP read-modify-write semantics

### DIFF
--- a/ci-tests/seip-rmw.S
+++ b/ci-tests/seip-rmw.S
@@ -1,0 +1,63 @@
+.section .text.init
+.globl _start
+_start:
+  li t0, 0x0c000004
+  li t1, 7
+  sw t1, 0(t0)
+
+  li t0, 0x0c201000
+  sw zero, 0(t0)
+
+  li t0, 0x0c002080
+  li t1, 2
+  sw t1, 0(t0)
+
+  li t0, 0x10000001
+  li t1, 2
+  sb t1, 0(t0)
+
+  li t0, 0x0c001000
+1:
+  lw t1, 0(t0)
+  andi t1, t1, 2
+  beqz t1, 1b
+
+  li t0, 1 << 5
+  csrrc t1, mip, t0
+  andi t1, t1, 1 << 9
+  beqz t1, fail
+
+  li t0, 0x10000001
+  sb zero, 0(t0)
+
+  li t0, 0x0c001000
+2:
+  lw t1, 0(t0)
+  andi t1, t1, 2
+  bnez t1, 2b
+
+  csrr t1, mip
+  andi t1, t1, 1 << 9
+  bnez t1, fail
+
+  li t1, 1
+  j exit
+
+fail:
+  li t1, 3
+
+exit:
+  lla t0, tohost
+  sd t1, 0(t0)
+3:
+  j 3b
+
+.section .tohost,"aw",@progbits
+.balign 64
+.globl tohost
+tohost:
+  .dword 0
+.balign 64
+.globl fromhost
+fromhost:
+  .dword 0

--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -27,6 +27,9 @@ riscv64-linux-gnu-gcc -static -O2 -o hello $CI/hello.c
 riscv64-linux-gnu-gcc -static -O2 -o dummy-slliuw $CI/dummy-slliuw.c
 riscv64-linux-gnu-gcc -static -O2 -o customcsr $CI/customcsr.c
 riscv64-linux-gnu-gcc -static -O2 -o atomics $CI/atomics.c
+riscv64-linux-gnu-gcc -nostdlib -nostartfiles -static -no-pie -fno-pie \
+  -Wl,--build-id=none -Wl,-Ttext-segment=0x80000000 \
+  -Wl,--section-start=.tohost=0x81000000 -o seip-rmw $CI/seip-rmw.S
 riscv64-linux-gnu-gcc -static -O2 -march=rv64gcv -o vector-sum $CI/vector-sum.c
 
 # run snippy-based tests
@@ -50,6 +53,7 @@ g++ -std=c++2a -I$INSTALL/include -L$INSTALL/lib $CI/testlib.cc -lriscv -o /dev/
 time $INSTALL/bin/spike --isa=rv64gc $BUILD/pk/pk hello | grep "Hello, world!  Pi is approximately 3.141588."
 time $INSTALL/bin/spike --isa=rv64gcv $BUILD/pk/pk vector-sum | grep "The sum of the first 1000 positive integers is 500500."
 $INSTALL/bin/spike --log-commits --isa=rv64gc $BUILD/pk/pk atomics 2> /dev/null | grep "First atomic counter is 1000, second is 100"
+time $INSTALL/bin/spike --isa=rv64gc seip-rmw
 LD_LIBRARY_PATH=$INSTALL/lib ./test-libriscv $BUILD/pk/pk hello | grep "Hello, world!  Pi is approximately 3.141588."
 LD_LIBRARY_PATH=$INSTALL/lib ./test-customext $BUILD/pk/pk dummy-slliuw | grep "Executed successfully"
 LD_LIBRARY_PATH=$INSTALL/lib ./test-custom-csr $BUILD/pk/pk customcsr | grep "Executed successfully"

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -967,6 +967,10 @@ reg_t mip_csr_t::read() const noexcept {
   return val | state->hvip->basic_csr_t::read() | ((state->mvien->read() & MIP_SEIP) ? 0 : (state->mvip->basic_csr_t::read() & MIP_SEIP));
 }
 
+reg_t mip_csr_t::read_for_write() const noexcept {
+  return (read() & ~MIP_SEIP) | (state->mvip->basic_csr_t::read() & MIP_SEIP);
+}
+
 void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
   this->val = (this->val & ~mask) | (val & mask);
 }

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -38,6 +38,11 @@ class csr_t {
   // checking needed or allowed. Side effects not allowed.
   virtual reg_t read() const noexcept = 0;
 
+  // Value used as the old value in a CSR read-modify-write operation.
+  // Most CSRs use their ordinary read value, but a CSR with an externally
+  // driven read value can override this to exclude that external input.
+  virtual reg_t read_for_write() const noexcept { return read(); }
+
   // write() updates the architectural value of this CSR. No
   // permission checking needed or allowed.
   // Child classes must implement unlogged_write()
@@ -389,6 +394,7 @@ class mip_csr_t: public mip_or_mie_csr_t {
  public:
   mip_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override final;
+  virtual reg_t read_for_write() const noexcept override final;
 
   void write_with_mask(const reg_t mask, const reg_t val) noexcept override;
 

--- a/riscv/insns/csrrc.h
+++ b/riscv/insns/csrrc.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->put_csr(csr, old & ~RS1);
+  p->put_csr(csr, p->get_csr_for_write(csr) & ~RS1);
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrci.h
+++ b/riscv/insns/csrrci.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->put_csr(csr, old & ~(reg_t)insn.rs1());
+  p->put_csr(csr, p->get_csr_for_write(csr) & ~(reg_t)insn.rs1());
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrs.h
+++ b/riscv/insns/csrrs.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->put_csr(csr, old | RS1);
+  p->put_csr(csr, p->get_csr_for_write(csr) | RS1);
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrsi.h
+++ b/riscv/insns/csrrsi.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->put_csr(csr, old | insn.rs1());
+  p->put_csr(csr, p->get_csr_for_write(csr) | insn.rs1());
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -656,6 +656,15 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
   throw trap_illegal_instruction(insn.bits());
 }
 
+reg_t processor_t::get_csr_for_write(int which)
+{
+  auto search = state.csrmap.find(which);
+  if (search != state.csrmap.end())
+    return search->second->read_for_write();
+
+  abort(); // The preceding permission-checked CSR read found this CSR.
+}
+
 const insn_desc_t insn_desc_t::illegal_instruction = {
   0, 0,
   &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction,

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -253,6 +253,7 @@ public:
   uint32_t get_id() const { return id; }
   reg_t get_csr(int which, insn_t insn, bool write, bool peek = 0);
   reg_t get_csr(int which) { return get_csr(which, insn_t(0), false, true); }
+  reg_t get_csr_for_write(int which);
   mmu_t* get_mmu() { return mmu; }
   state_t* get_state() { return &state; }
   unsigned get_xlen() const { return xlen; }


### PR DESCRIPTION
Fixes #2360.

`mip.SEIP` reads as the OR of its software-writable bit and the external interrupt-controller signal. CSRRS and CSRRC were feeding that combined read value back into the write, which could latch an asserted external SEIP signal into the software bit.

This adds a separate read value for CSR read-modify-write operations. Most CSRs use their normal read value; `mip` excludes the externally driven SEIP contribution while retaining the software-writable bit. The value returned to `rd` is unchanged.

The regression raises SEIP through the PLIC, performs a CSRRC operation on an unrelated `mip` bit, clears the PLIC source, and checks that SEIP does not remain set.

Tested on a clean Debian 12 VM:

- Regression fails against unmodified `master` (exit 1)
- Regression passes with this patch (exit 0)
- `make check` passes