### PR TITLE
Fix MNRET double-trap state cleanup

### DIFF
--- a/ci-tests/mnret-double-trap-rv32.cmd
+++ b/ci-tests/mnret-double-trap-rv32.cmd
@@ -1,0 +1,5 @@
+until pc 0 81000000
+reg 0 mstatus
+reg 0 mstatush
+reg 0 vsstatus
+quit

--- a/ci-tests/mnret-double-trap.S
+++ b/ci-tests/mnret-double-trap.S
@@ -1,0 +1,43 @@
+#ifndef MNRET_MNPP
+#define MNRET_MNPP 0
+#endif
+
+#ifndef MNRET_MNPV
+#define MNRET_MNPV 0
+#endif
+
+  .section .text.init
+  .globl _start
+_start:
+#if __riscv_xlen == 64
+  li t0, 1 << 59
+  csrw menvcfg, t0
+  csrw henvcfg, t0
+#else
+  li t0, 1 << 27
+  csrw menvcfgh, t0
+  csrw henvcfgh, t0
+#endif
+
+  li t0, 1 << 24
+  csrw vsstatus, t0
+
+#if __riscv_xlen == 64
+  li t0, (1 << 42) | (1 << 24) | (1 << 17)
+  csrw mstatus, t0
+#else
+  li t0, 1 << 10
+  csrw mstatush, t0
+  li t0, (1 << 24) | (1 << 17)
+  csrw mstatus, t0
+#endif
+
+  li t0, (MNRET_MNPP << 11) | (MNRET_MNPV << 7)
+  csrw 0x744, t0
+  lla t0, mnret_target
+  csrw 0x741, t0
+  .word 0x70200073
+
+  .section .mnret_target,"ax",@progbits
+mnret_target:
+  j mnret_target

--- a/ci-tests/mnret-double-trap.cmd
+++ b/ci-tests/mnret-double-trap.cmd
@@ -1,0 +1,4 @@
+until pc 0 81000000
+reg 0 mstatus
+reg 0 vsstatus
+quit

--- a/ci-tests/test-mnret-double-trap
+++ b/ci-tests/test-mnret-double-trap
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+SPIKE=$1
+RUN=$2
+CI="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+mkdir -p "$RUN"
+cd "$RUN"
+
+for xlen in 32 64; do
+  for mode in s u vs vu; do
+    case $mode in
+      s)  mnpp=1; mnpv=0 ;;
+      u)  mnpp=0; mnpv=0 ;;
+      vs) mnpp=1; mnpv=1 ;;
+      vu) mnpp=0; mnpv=1 ;;
+    esac
+    riscv64-linux-gnu-gcc -nostdlib -nostartfiles -static -no-pie -fno-pie \
+      -march=rv${xlen}gc -mabi=$(test $xlen -eq 64 && echo lp64d || echo ilp32d) \
+      -Wl,--build-id=none -Wl,-Ttext-segment=0x80000000 \
+      -Wl,--section-start=.mnret_target=0x81000000 \
+      -DMNRET_MNPP=$mnpp -DMNRET_MNPV=$mnpv \
+      -o mnret-double-trap-rv${xlen}-$mode "$CI/mnret-double-trap.S"
+  done
+done
+
+for xlen in 32 64; do
+  for mode in s u vs vu; do
+    debug_cmd="$CI/mnret-double-trap.cmd"
+    if test $xlen -eq 32; then
+      debug_cmd="$CI/mnret-double-trap-rv32.cmd"
+    fi
+    output=$(
+      "$SPIKE" -d --isa=rv${xlen}gch_smrnmi_smdbltrp_ssdbltrp \
+        --debug-cmd="$debug_cmd" mnret-double-trap-rv${xlen}-$mode 2>&1
+    )
+    mapfile -t status < <(sed -n 's/^0x//p' <<< "$output")
+    expected_status_count=$((xlen == 32 ? 3 : 2))
+    if test ${#status[@]} -ne $expected_status_count; then
+      echo "Failed to read RV$xlen MNRET status for $mode mode" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+
+    mstatus=$((16#${status[0]}))
+    if test $xlen -eq 32; then
+      mstatush=$((16#${status[1]}))
+      vsstatus=$((16#${status[2]}))
+      mdt=$((mstatush & (1 << 10)))
+    else
+      vsstatus=$((16#${status[1]}))
+      mdt=$((mstatus & (1 << 42)))
+    fi
+
+    if test $mdt -ne 0; then
+      echo "RV$xlen MNRET left mstatus.MDT set when returning to $mode mode" >&2
+      exit 1
+    fi
+
+    case $mode in
+      s)
+        test $((mstatus & (1 << 24))) -ne 0
+        test $((vsstatus & (1 << 24))) -ne 0
+        ;;
+      u|vs)
+        test $((mstatus & (1 << 24))) -eq 0
+        test $((vsstatus & (1 << 24))) -ne 0
+        ;;
+      vu)
+        test $((mstatus & (1 << 24))) -eq 0
+        test $((vsstatus & (1 << 24))) -eq 0
+        ;;
+    esac
+  done
+done

--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -50,6 +50,7 @@ g++ -std=c++2a -I$INSTALL/include -L$INSTALL/lib $CI/testlib.cc -lriscv -o /dev/
 time $INSTALL/bin/spike --isa=rv64gc $BUILD/pk/pk hello | grep "Hello, world!  Pi is approximately 3.141588."
 time $INSTALL/bin/spike --isa=rv64gcv $BUILD/pk/pk vector-sum | grep "The sum of the first 1000 positive integers is 500500."
 $INSTALL/bin/spike --log-commits --isa=rv64gc $BUILD/pk/pk atomics 2> /dev/null | grep "First atomic counter is 1000, second is 100"
+bash $CI/test-mnret-double-trap $INSTALL/bin/spike $RUN/mnret-double-trap
 LD_LIBRARY_PATH=$INSTALL/lib ./test-libriscv $BUILD/pk/pk hello | grep "Hello, world!  Pi is approximately 3.141588."
 LD_LIBRARY_PATH=$INSTALL/lib ./test-customext $BUILD/pk/pk dummy-slliuw | grep "Executed successfully"
 LD_LIBRARY_PATH=$INSTALL/lib ./test-custom-csr $BUILD/pk/pk customcsr | grep "Executed successfully"

--- a/riscv/insns/mnret.h
+++ b/riscv/insns/mnret.h
@@ -7,7 +7,13 @@ reg_t prev_virt = get_field(s, MNSTATUS_MNPV);
 if (prev_prv != PRV_M) {
   reg_t mstatus = STATE.mstatus->read();
   mstatus = set_field(mstatus, MSTATUS_MPRV, 0);
+  mstatus = set_field(mstatus, MSTATUS_MDT, 0);
+  if (prev_prv == PRV_U || prev_virt)
+    mstatus = set_field(mstatus, MSTATUS_SDT, 0);
+  if (prev_virt && prev_prv == PRV_U)
+    STATE.vsstatus->write(STATE.vsstatus->read() & ~SSTATUS_SDT);
   STATE.mstatus->write(mstatus);
+  if (STATE.mstatush) STATE.mstatush->write(mstatus >> 32);
 }
 s = set_field(s, MNSTATUS_NMIE, 1);
 if (ZICFILP_xLPE(prev_virt, prev_prv)) {


### PR DESCRIPTION
Fixes #2214.

`MNRET` clears `MPRV` when returning below M-mode, but currently leaves the double-trap state unchanged. The privileged spec requires it to clear `MDT` for any return below M-mode, clear `sstatus.SDT` for U, VS, or VU, and clear `vsstatus.SDT` for VU.

This patch applies those transitions, updates `mstatush` on RV32, and adds RV32/RV64 coverage for returns to S, U, VS, and VU.

Tested on a clean GCP VM:
- The regression fails on unmodified `master`
- All eight patched cases pass
- `make check` passes