### PR TITLE
Add FIOM to the menvcfg, senvcfg, and henvcfg write masks

### DIFF
--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -236,7 +236,11 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     add_hypervisor_csr(CSR_HIDELEG, hideleg);
   }
 
-  const reg_t menvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? MENVCFG_CBCFE | MENVCFG_CBIE : 0) |
+  // The spec allows FIOM to read as zero only where there is no S-mode or no
+  // paging, so it is writable exactly when neither holds.
+  const bool fiom_writable = proc->extension_enabled('S') && proc->get_max_vaddr_bits() > 0;
+  const reg_t menvcfg_mask = (fiom_writable ? MENVCFG_FIOM : 0) |
+                            (proc->extension_enabled(EXT_ZICBOM) ? MENVCFG_CBCFE | MENVCFG_CBIE : 0) |
                             (proc->extension_enabled(EXT_ZICBOZ) ? MENVCFG_CBZE : 0) |
                             (proc->extension_enabled(EXT_SMNPM) ? MENVCFG_PMM : 0) |
                             (proc->extension_enabled(EXT_SVADU) ? MENVCFG_ADUE: 0) |
@@ -346,14 +350,16 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   add_csr(CSR_MVENDORID, std::make_shared<const_csr_t>(proc, CSR_MVENDORID, 0));
   add_csr(CSR_MHARTID, std::make_shared<const_csr_t>(proc, CSR_MHARTID, proc->get_id()));
   add_csr(CSR_MCONFIGPTR, std::make_shared<const_csr_t>(proc, CSR_MCONFIGPTR, 0));
-  const reg_t senvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? SENVCFG_CBCFE | SENVCFG_CBIE : 0) |
+  const reg_t senvcfg_mask = (fiom_writable ? SENVCFG_FIOM : 0) |
+                            (proc->extension_enabled(EXT_ZICBOM) ? SENVCFG_CBCFE | SENVCFG_CBIE : 0) |
                             (proc->extension_enabled(EXT_ZICBOZ) ? SENVCFG_CBZE : 0) |
                             (proc->extension_enabled(EXT_SVUKTE) ? SENVCFG_UKTE : 0) |
                             (proc->extension_enabled(EXT_SSNPM) ? SENVCFG_PMM : 0) |
                             (proc->extension_enabled(EXT_ZICFILP) ? SENVCFG_LPE : 0) |
                             (proc->extension_enabled(EXT_ZICFISS) ? SENVCFG_SSE : 0);
   add_supervisor_csr(CSR_SENVCFG, senvcfg = std::make_shared<senvcfg_csr_t>(proc, CSR_SENVCFG, senvcfg_mask, 0));
-  const reg_t henvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? HENVCFG_CBCFE | HENVCFG_CBIE : 0) |
+  const reg_t henvcfg_mask = HENVCFG_FIOM |
+                            (proc->extension_enabled(EXT_ZICBOM) ? HENVCFG_CBCFE | HENVCFG_CBIE : 0) |
                             (proc->extension_enabled(EXT_ZICBOZ) ? HENVCFG_CBZE : 0) |
                             (proc->extension_enabled(EXT_SSNPM) ? HENVCFG_PMM : 0) |
                             (proc->extension_enabled(EXT_SVADU) ? HENVCFG_ADUE: 0) |


### PR DESCRIPTION
Fixes #1837.

FIOM (bit 0) is missing from all three `*envcfg` write masks, so writes to `menvcfg.FIOM`, `senvcfg.FIOM` and `henvcfg.FIOM` are discarded and the bit always reads zero.

The privileged spec allows tying FIOM off only when S-mode is unsupported or `satp`.MODE is read-only zero (`menvcfg`), or the latter alone (`senvcfg`); `henvcfg` carries no such allowance. Spike supports S-mode and paging, so none of the three qualifies. `henvcfg.FIOM` stays independent of `menvcfg`, matching the spec — `henvcfg_csr_t::unlogged_write` gates only PBMTE, STCE, ADUE, DTE and SSE.

Nothing is left unimplemented behind the bit: FIOM only strengthens FENCE and ordered-atomic semantics, and Spike does not reorder memory accesses (`riscv/insns/fence.h` is empty), so that ordering already holds unconditionally.

Tested with a bare-metal program that writes 1 to each CSR and reports the bit that reads back, on an unpatched and a patched build (M-mode, `--isa=rv64gch`): `0/0/0` before, `1/1/1` after.
