### PR TITLE
triggers: avoid oversized shifts for NAPOT matching

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -215,7 +215,10 @@ bool mcontrol_common_t::simple_match(unsigned xlen, reg_t value) const {
       return value == tdata2;
     case MATCH_NAPOT:
       {
-        reg_t mask = ~((1 << (cto(tdata2)+1)) - 1);
+        const unsigned trailing_ones = cto(tdata2) + 1;
+        reg_t mask = 0;
+        if (trailing_ones < xlen)
+          mask = ~((reg_t(1) << trailing_ones) - 1);
         return (value & mask) == (tdata2 & mask);
       }
     case MATCH_GE:


### PR DESCRIPTION
Build the NAPOT mask with the target register type and avoid shifting by the target XLEN. This removes undefined host-integer shifts and handles a full-width NAPOT range with a zero comparison mask.