### PR TITLE
debug: preserve arg1 across abstract memory writes

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -954,6 +954,7 @@ void debug_module_t::handle_memory_write(size_t xlen, unsigned aamsize, unsigned
   write32(debug_abstract, offset++, sx[aamsize](S0, S1, 0));
 
   write32(debug_abstract, offset++, lx[idx(xlen)](S0, ZERO, arg(xlen, 1))); // Restore S0
+  write32(debug_abstract, offset++, sx[idx(xlen)](S1, ZERO, arg(xlen, 1))); // Restore Arg1
 }
 
 void debug_module_t::handle_post_increment(size_t xlen, unsigned aamsize, unsigned &offset)


### PR DESCRIPTION
Restore the abstract memory address from S1 to arg1 after restoring mstatus. The existing postincrement sequence then advances the original address instead of the temporary mstatus value.