### PR TITLE
[NFC] Use std::string::starts_with() instead of substr/compare/find idioms

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,26 @@
+Checks: 'modernize-*, 
+         portability-*, 
+         concurrency-*, 
+         performance-*, 
+         -concurrency-mt-unsafe, 
+         -performance-avoid-endl, 
+         -performance-enum-size, 
+         -performance-no-int-to-ptr, 
+         -modernize-use-trailing-return-type, 
+         -modernize-use-nodiscard, 
+         -modernize-avoid-c-style-cast, 
+         -modernize-use-designated-initializers, 
+         -modernize-use-trailing-return-type, 
+         -modernize-macro-to-enum, 
+         -modernize-use-auto, 
+         -modernize-type-traits, 
+         -modernize-use-using,
+         -modernize-avoid-c-arrays,
+         -modernize-use-default-member-init,
+         -modernize-use-integer-sign-comparison,
+         -modernize-use-ranges
+         '
+WarningsAsErrors: '* '
+
+HeaderFilterRegex: '.*'
+ExcludeHeaderFilterRegex: 'softfloat/.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,25 +1,4 @@
-Checks: 'modernize-*, 
-         portability-*, 
-         concurrency-*, 
-         performance-*, 
-         -concurrency-mt-unsafe, 
-         -performance-avoid-endl, 
-         -performance-enum-size, 
-         -performance-no-int-to-ptr, 
-         -modernize-use-trailing-return-type, 
-         -modernize-use-nodiscard, 
-         -modernize-avoid-c-style-cast, 
-         -modernize-use-designated-initializers, 
-         -modernize-use-trailing-return-type, 
-         -modernize-macro-to-enum, 
-         -modernize-use-auto, 
-         -modernize-type-traits, 
-         -modernize-use-using,
-         -modernize-avoid-c-arrays,
-         -modernize-use-default-member-init,
-         -modernize-use-integer-sign-comparison,
-         -modernize-use-ranges
-         '
+Checks: 'modernize-use-starts-ends-with'
 WarningsAsErrors: '* '
 
 HeaderFilterRegex: '.*'

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -316,9 +316,9 @@ void isa_parser_t::add_extension(const std::string& ext_str, const char* str)
     for (const auto implied : info->implies) {
       add_extension(implied, str);
     }
-    if (ext_str.substr(0, 3) == "zve")
+    if (ext_str.starts_with("zve"))
       apply_zve_properties(ext_str, str);
-  } else if (ext_str.substr(0, 3) == "zvl") {
+  } else if (ext_str.starts_with("zvl")) {
     reg_t new_vlen;
     try {
       new_vlen = safe_stoul(ext_str.substr(3, ext_str.size() - 4));
@@ -345,9 +345,9 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   isa_string = strtolower(str);
   const char* all_subsets = "mafdqcbpvh";
 
-  if (isa_string.compare(0, 4, "rv32") == 0)
+  if (isa_string.starts_with("rv32"))
     max_xlen = 32;
-  else if (isa_string.compare(0, 4, "rv64") == 0)
+  else if (isa_string.starts_with("rv64"))
     max_xlen = 64;
   else
     bad_isa_string(str, "ISA strings must begin with RV32 or RV64");

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -400,45 +400,45 @@ void htif_t::parse_arguments(int argc, char ** argv)
           c = HTIF_LONG_OPTIONS_OPTIND;
           optarg = nullptr;
         }
-        else if (arg.find("+rfb=") == 0) {
+        else if (arg.starts_with("+rfb=")) {
           c = HTIF_LONG_OPTIONS_OPTIND;
           optarg = optarg + 5;
         }
-        else if (arg.find("+disk=") == 0) {
+        else if (arg.starts_with("+disk=")) {
           c = HTIF_LONG_OPTIONS_OPTIND + 1;
           optarg = optarg + 6;
         }
-        else if (arg.find("+signature=") == 0) {
+        else if (arg.starts_with("+signature=")) {
           c = HTIF_LONG_OPTIONS_OPTIND + 2;
           optarg = optarg + 11;
         }
-        else if (arg.find("+chroot=") == 0) {
+        else if (arg.starts_with("+chroot=")) {
           c = HTIF_LONG_OPTIONS_OPTIND + 3;
           optarg = optarg + 8;
         }
-        else if (arg.find("+payload=") == 0) {
+        else if (arg.starts_with("+payload=")) {
           c = HTIF_LONG_OPTIONS_OPTIND + 4;
           optarg = optarg + 9;
         }
-        else if (arg.find("+signature-granularity=") == 0) {
+        else if (arg.starts_with("+signature-granularity=")) {
           c = HTIF_LONG_OPTIONS_OPTIND + 5;
           optarg = optarg + 23;
         }
-	else if (arg.find("+target-argument=") == 0) {
+	else if (arg.starts_with("+target-argument=")) {
 	  c = HTIF_LONG_OPTIONS_OPTIND + 6;
 	  optarg = optarg + 17;
 	}
-        else if (arg.find("+symbol-elf=") == 0) {
+        else if (arg.starts_with("+symbol-elf=")) {
           c = HTIF_LONG_OPTIONS_OPTIND + 7;
           optarg = optarg + 12;
         }
-        else if (arg.find("+permissive-off") == 0) {
+        else if (arg.starts_with("+permissive-off")) {
           if (opterr)
             throw std::invalid_argument("Found +permissive-off when not parsing permissively");
           opterr = 1;
           break;
         }
-        else if (arg.find("+permissive") == 0) {
+        else if (arg.starts_with("+permissive")) {
           if (!opterr)
             throw std::invalid_argument("Found +permissive when already parsing permissively");
           opterr = 0;


### PR DESCRIPTION
Add .clang-tidy configuration to enforce this.

.clang-tidy will conflict depending on order of merges.  Will update this or other PRs based on order.