### PR TITLE
fix(smdbltrp): SRET unconditionally clears sstatus.SDT in M-mode

### DIFF
--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -29,8 +29,7 @@ if (ZICFILP_xLPE(prev_virt, prev_prv)) {
 
 if (STATE.prv == PRV_M) {
   STATE.mstatus->write(STATE.mstatus->read() & ~MSTATUS_MDT);
-  if (prev_prv == PRV_U || prev_virt)
-    s = set_field(s, SSTATUS_SDT, 0);
+  s = set_field(s, SSTATUS_SDT, 0);
   if (prev_virt && prev_prv == PRV_U)
     STATE.vsstatus->write(STATE.vsstatus->read() & ~SSTATUS_SDT);
 }


### PR DESCRIPTION
Fixes #2376

According to the Double Trap Extension specification, when an `SRET` instruction is executed, the `sdt` bit is unconditionally set to 0. 

Previously in `sret.h`, if `SRET` was executed in M-mode, the clearing of `SSTATUS_SDT` was guarded by `if (prev_prv == PRV_U || prev_virt)`, which incorrectly skipped clearing the bit when returning to S-mode without virtualization.

This PR removes that conditional check so `SSTATUS_SDT` is unconditionally cleared, matching the behavior specified in the ISA manual.